### PR TITLE
chore: Add explicit redirect to homepage

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -270,5 +270,11 @@
     "telemetry": {
       "enabled": false
     }
-  }
+  },
+  "redirects": [
+    {
+      "source": "/:page*",
+      "destination": "/docs/home"
+    }
+  ]
 }


### PR DESCRIPTION
Mirrors behavior for Mintlify when no auth is set (e.g. instead of 404-ing redirect to homepage)