### PR TITLE
feat: Add redirects for pages to maintain SEO

### DIFF
--- a/api-reference/translate.mdx
+++ b/api-reference/translate.mdx
@@ -337,7 +337,7 @@ Note that the `quality_optimized` value for the `model_type` parameter is curren
 
 The behavior of the `model_type` parameter when the `quality_optimized` or `prefer_quality_optimized` values are sent in a request depends on language pairs that are supported by DeepL’s next-gen translation models.
 
-Currently, all source and target languages are supported by next-gen models. In the future, if we add language pairs that are not supported by next-gen models, a request will fail (if `model_type` is set to `quality_optimized`) or fall back to classic models (if `model_type` is set to `prefer_quality_optimized`) if the chosen langauge pair does not support next-gen models.
+Currently, all source and target languages are supported by next-gen models. In the future, if we add language pairs that are not supported by next-gen models, a request will fail (if `model_type` is set to `quality_optimized`) or fall back to classic models (if `model_type` is set to `prefer_quality_optimized`) if the chosen language pair does not support next-gen models.
 
 The `/languages` endpoint has not yet been updated to include information about `model_type` support, but we expect to make such a change in the future.
 

--- a/docs.json
+++ b/docs.json
@@ -333,10 +333,6 @@
     "destination": "/docs/resources/breaking-changes-change-notices/march-2025-deprecating-get-requests-to-translate-and-authenticating-with-auth_key"
   },
   {
-    "source": "/docs/learning-how-tos/cookbook/:page*",
-    "destination": "/docs/learning-how-tos/examples-and-guides/:page*"
-  },
-  {
     "source": "/deepl-api-docs",
     "destination": "/docs"
   }


### PR DESCRIPTION
Overall differences between Mintlify and Gitbook:
- `docs/api-reference` is now redirecting to `/api-reference`
- `/.../~gitbook/image` pages no longer exist
- Mintlify now has an API playground per endpoint, where on Gitbook, we had a OpenAPI generated doc page per group of endpoints. I added redirects to redirect users to the appropriate API playground for the old endpoint pages 
- Moved some of the hidden pages (e.g. `/multiple-api-keys` to fall under the `/docs/` subpath)
- Removed `/docs/learning-how-tos/examples-and-guides/deepl-api-101` and that now redirects to `docs/learning-how-tos/examples-and-guides/deepl-api-101/first-things-to-try-with-the-deepl-api`
- Gitbook's main page is `developer.deepl.com/docs` but that now redirects to `docs/getting-started/intro`


This PR also adds some redirects that exist on Gitbook (namely around the cookbook but also like https://developers.deepl.com/docs/resources/breaking-changes-change-notices/february-2025-deprecating-get-requests-to-translate-and-authenticating-with-auth_key which is a redirect that changes the february-2025 to march-2025