### PR TITLE
feat: Add newest languages to API docs

### DIFF
--- a/api-reference/openapi.yaml
+++ b/api-reference/openapi.yaml
@@ -2221,9 +2221,11 @@ components:
       - EN-GB
       - EN-US
       - ES
+      - ES-419
       - ET
       - FI
       - FR
+      - HE
       - HU
       - ID
       - IT
@@ -2241,8 +2243,10 @@ components:
       - SK
       - SL
       - SV
+      - TH
       - TR
       - UK
+      - VI
       - ZH
       - ZH-HANS
       - ZH-HANT

--- a/docs/getting-started/supported-languages.mdx
+++ b/docs/getting-started/supported-languages.mdx
@@ -17,11 +17,11 @@ Please note that Hebrew, Thai and Vietnamese have not been added to the `/langua
 * `DE` - German
 * `EL` - Greek
 * `EN` - English (all English variants)
-* `ES` - Spanish
+* `ES` - Spanish (all Spanish variants)
 * `ET` - Estonian
 * `FI` - Finnish
 * `FR` - French
-* `HE` - Hebrew (Pro v2 API, next-gen models only)
+* `HE` - Hebrew (text translation via next-gen models only)
 * `HU` - Hungarian
 * `ID` - Indonesian
 * `IT` - Italian
@@ -38,10 +38,10 @@ Please note that Hebrew, Thai and Vietnamese have not been added to the `/langua
 * `SK` - Slovak
 * `SL` - Slovenian
 * `SV` - Swedish
-* `TH` - Thai (Pro v2 API, text translation via next-gen models only)
+* `TH` - Thai (text translation via next-gen models only)
 * `TR` - Turkish
 * `UK` - Ukrainian
-* `VI` - Vietnamese (Pro v2 API, next-gen models only)
+* `VI` - Vietnamese (text translation via next-gen models only)
 * `ZH` - Chinese (all Chinese variants)
 
 ### Translation target languages
@@ -56,10 +56,11 @@ Please note that Hebrew, Thai and Vietnamese have not been added to the `/langua
 * `EN-GB` - English (British)
 * `EN-US` - English (American)
 * `ES` - Spanish
+* `ES-419` - Spanish (Latin American)
 * `ET` - Estonian
 * `FI` - Finnish
 * `FR` - French
-* `HE` - Hebrew (Pro v2 API, next-gen models only)
+* `HE` - Hebrew (text translation via next-gen models only)
 * `HU` - Hungarian
 * `ID` - Indonesian
 * `IT` - Italian
@@ -78,10 +79,10 @@ Please note that Hebrew, Thai and Vietnamese have not been added to the `/langua
 * `SK` - Slovak
 * `SL` - Slovenian
 * `SV` - Swedish
-* `TH` - Thai (Pro v2 API, text translation via next-gen models only)
+* `TH` - Thai (text translation via next-gen models only)
 * `TR` - Turkish
 * `UK` - Ukrainian
-* `VI` - Vietnamese (Pro v2 API, next-gen models only)
+* `VI` - Vietnamese (text translation via next-gen models only)
 * `ZH` - Chinese (unspecified variant for backward compatibility; please select `ZH-HANS` or `ZH-HANT` instead)
 * `ZH-HANS` - Chinese (simplified)
 * `ZH-HANT` - Chinese (traditional)


### PR DESCRIPTION
Adds:

- Hebrew, Vietnamese and Thai to the openapi spec used in this repo (TODO: Check the real openapi repo) for text translation across Pro, Free and v1 API
- Latin american spanish to text translation

Checked it doesnt show up in doctrans/glossary, checked with `mintlify dev`

Missing: Adding `es-ES` as an alias for castilian spanish (to be consistent with other variants), not yet supported in the API.