### PR TITLE
Add breaking change notice for legacy authentication

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -98,7 +98,7 @@
                   "docs/resources/breaking-changes-change-notices",
                   "docs/resources/breaking-changes-change-notices/july-2024-deprecation-of-insecure-cipher-suites",
                   "docs/resources/breaking-changes-change-notices/march-2025-deprecating-get-requests-to-translate-and-authenticating-with-auth_key",
-                  "docs/resources/breaking-changes-change-notices/august-2025-deprecation-of-legacy-auth-methods"
+                  "docs/resources/breaking-changes-change-notices/november-2025-deprecation-of-legacy-auth-methods"
                 ]
               },
               "docs/resources/language-release-process",

--- a/docs/resources/breaking-changes-change-notices.mdx
+++ b/docs/resources/breaking-changes-change-notices.mdx
@@ -11,5 +11,5 @@ To learn about new releases, please see the [Release notes](/docs/resources/rele
 </Card>
 <Card title='March 2025: Deprecating GET requests to /translate and authenticating with auth_key' href="/docs/resources/breaking-changes-change-notices/march-2025-deprecating-get-requests-to-translate-and-authenticating-with-auth_key">
 </Card>
-<Card title='August 2025: Deprecating query parameter and request body authentication' href="/docs/resources/breaking-changes-change-notices/august-2025-deprecation-of-legacy-auth-methods">
+<Card title='November 2025: Deprecating query parameter and request body authentication' href="/docs/resources/breaking-changes-change-notices/november-2025-deprecation-of-legacy-auth-methods">
 </Card>

--- a/docs/resources/breaking-changes-change-notices/november-2025-deprecation-of-legacy-auth-methods.mdx
+++ b/docs/resources/breaking-changes-change-notices/november-2025-deprecation-of-legacy-auth-methods.mdx
@@ -1,14 +1,14 @@
 ---
-title: "August 2025: Deprecation of query parameter and request body authentication"
+title: "November 2025: Deprecation of query parameter and request body authentication"
 ---
 
 ## Change Notice
 
-On or after TBD, DeepL will fully obsolesce support for providing authentication information in an `auth_key` query parameter or in an `auth_key` field of the request body.
+On November 1st, 2025, DeepL will fully obsolesce support for providing authentication information in an `auth_key` query parameter or in an `auth_key` field of the request body.
 
 Deprecation of this feature was previously announced in [March 2025](/docs/resources/breaking-changes-change-notices/march-2025-deprecating-get-requests-to-translate-and-authenticating-with-auth_key), but we have continued to support it temporarily to allow more time for customers to complete the migration.
 
-You will no longer be able to authenticate a request to any endpoint by sending an API key in a query parameter or request body. Instead, send your API key in an HTTP header named Authorization .
+You will no longer be able to authenticate a request to any endpoint by sending an API key in a query parameter or request body. Instead, send your API key in an HTTP header named `Authorization`.
 
 * **You will no longer be able to authenticate a request to any endpoint by sending an API key in a query parameter or in the request body.** Instead, send your API key in an HTTP header named `Authorization` .
 * **If you use one of DeepL's officially-supported client libraries, you won't be negatively affected by the breaking changes and do not need to update your application.** Specifically, we've confirmed the following client library versions:


### PR DESCRIPTION
Legacy API authentication methods will be fully deprecated. Target date is November 1st 2025