### PR TITLE
feat: Add API playground for /languages

### DIFF
--- a/api-reference/languages/retrieve-supported-languages.mdx
+++ b/api-reference/languages/retrieve-supported-languages.mdx
@@ -1,5 +1,4 @@
 ---
 openapi: get /v2/languages
 title: "Retrieve supported languages"
-playground: none
 ---


### PR DESCRIPTION
Since the /languages endpoints are now in the Public API service, we shouldn't have a CORS issue when calling the endpoints now. As a result, we can create an API playground in the API documentation