### PR TITLE
Add update for legacy authentication methods deprecation

### DIFF
--- a/docs/resources/breaking-changes-change-notices/november-2025-deprecation-of-legacy-auth-methods.mdx
+++ b/docs/resources/breaking-changes-change-notices/november-2025-deprecation-of-legacy-auth-methods.mdx
@@ -5,7 +5,7 @@ title: "November 2025: Deprecation of query parameter and request body authentic
 ## Change Notice
 
 <Info>
-Update: The deadline for this deprecation has been extended to January 15th, 2026. ([notice](/docs/resources/breaking-changes-change-notices/november-2025-deprecation-of-legacy-auth-methods-update))
+Update: The deadline for this deprecation has been extended to January 15th, 2026.
 </Info>
 
 On November 1st, 2025, DeepL will fully obsolesce support for providing authentication information in an `auth_key` query parameter or in an `auth_key` field of the request body.


### PR DESCRIPTION
Updates target data for legacy authentication deprecation to January 15th, 2026, to allow users more time to complete migration.