### PR TITLE
Help Mintlify generate a proper internal page link

### DIFF
--- a/docs/getting-started/supported-languages.mdx
+++ b/docs/getting-started/supported-languages.mdx
@@ -5,7 +5,7 @@ public: true
 ---
 
 <Info>
-If trying to convert between variants of the same language (e.g. `EN-US` to `EN-GB`), please consider using the [/write/rephrase](/api-reference/improve-text) API. Please see [here](supported-languages#text-improvement-languages-deepl-api-for-write) for supported target languages for this use case.
+If trying to convert between variants of the same language (e.g. `EN-US` to `EN-GB`), please consider using the [/write/rephrase](/api-reference/improve-text) API. Please see [here](#text-improvement-languages-deepl-api-for-write) for supported target languages for this use case.
 </Info>
 
 ### Translation source languages


### PR DESCRIPTION
This fixes a tiny issue in which:

-  `mint dev` complains there's a broken link
- Clicking on the link opens a new tab instead of just moving down the page to the anchor