### PR TITLE
Add Pricing link, place in Getting Started section

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -41,6 +41,7 @@
               "docs/getting-started/about",
               "docs/getting-started/auth",
               "docs/getting-started/client-libraries",
+              "docs/getting-started/pricing",
               "docs/getting-started/managing-api-keys",
               "docs/getting-started/your-first-api-request",
               "docs/getting-started/test-your-api-requests-with-postman",

--- a/docs/getting-started/pricing.mdx
+++ b/docs/getting-started/pricing.mdx
@@ -1,0 +1,4 @@
+---
+title: "Pricing"
+url: "https://www.deepl.com/en/pro/change-plan#developer"
+---


### PR DESCRIPTION
This is how Mintlify makes us make external links. The other option would be to use an "anchors" object, but this seems more flexible.