### PR TITLE
Fix experience between 880-1024 px widths

### DIFF
--- a/tablet-width.css
+++ b/tablet-width.css
@@ -1,6 +1,6 @@
 /* These rules allow us to retain most elements of the desktop view between 880px and 1024px.
  * We could extend these all the way to the traditional 768px breakpoint,
- * but the widh of our current left sidebar makes that undesirable.
+ * but the width of our current left sidebar makes that undesirable.
  *
  * Mintlify provides an id for most of the areas we want to fix up.
  * For the rest, they use a `lg:hidden` class on the element to be shown at desktop
@@ -32,8 +32,16 @@
   }
 
 /* Retain full searchbar */
-  #navbar .h-full .hidden.flex-1.justify-center {
-    display: block;
+  @supports selector(:has()) {
+    div:has(> #search-bar-entry) {
+      display: block;
+    }
+  }
+
+  @supports not selector(:has()) {
+    #navbar .h-full .hidden.flex-1.justify-center {
+      display: block;
+    }
   }
 
 /* Hide little search control */
@@ -42,8 +50,16 @@
   }
 
 /* Retain tabs */
-  #navbar .hidden.px-12.h-12 {
-    display: block;
+  @supports selector(:has()) {
+    div:has(> .nav-tabs) {
+      display: block;
+    }
+  }
+
+  @supports not selector(:has()) {
+    #navbar .hidden.px-12.h-12 {
+      display: block;
+    }
   }
 
 /* Hide mobile menu */


### PR DESCRIPTION
### Summary
Tweak Mintlify CSS so that we don't simply show the quite inferior mobile view when someone shrinks their desktop browser window to <1024px width. Instead, continue to show the sidebar, the search bar, and most other elements until the window really gets too small.

### Rationale
Currently the experience on desktop browsers at widths <1024 px is quite inferior:

![Xnip2025-12-23_16-50-07](https://github.com/user-attachments/assets/da577e5a-0d69-4431-beba-766cb666bee1)

This PR improves matters:

![Xnip2025-12-23_16-49-54](https://github.com/user-attachments/assets/aef896d1-f769-4b19-9f99-e4708c8997d3)

I can't find stats right now, but I remember seeing a few years ago that a significant percentage of page views on desktop involved widths < 1024px. So I do believe this is an experience well worth fixing.

The downside, of course, is that overriding Mintlify's CSS may harm maintainability. They might change their CSS in ways that make ours substandard. Of course, our experience is so substandard now!

I tried to at least write CSS that was maintainable - that involved selectors that would seldom change whenever possible, that followed a predictable pattern, and that is carefully commented. If certain bits seem undesirable, we can also remove those bits - as once I did the most important thing, which is keeping the sidebar and tabs visible, I made further tweaks to increase our horizontal space, trying to overcome the challenge of our wide left sidebar (which, for example, [OpenAI made very narrow](https://platform.openai.com/docs/overview)).