### PR TITLE
rewrite variants guide with diataxis-style subagent

### DIFF
--- a/docs/learning-how-tos/examples-and-guides/translating-between-variants.mdx
+++ b/docs/learning-how-tos/examples-and-guides/translating-between-variants.mdx
@@ -1,30 +1,71 @@
 ---
 title: "Translating Between Language Variants"
-description: "Learn how to translate between variants of the same language, such as en-US to en-GB"
+description: "Learn how to translate between language variants, like British English and US English, using the DeepL API."
 public: true
 ---
 
-You can use the DeepL API to translate between variants of the same language (for example, `pt-PT` to `pt-BR` or `en-US` to `en-GB`) using several methods:
+**This guide shows you:**
+- How to translate between language variants (e.g., `en-US` to `en-GB`, `pt-PT` to `pt-BR`)
+- Which method to choose: Write API, style rules, or custom instructions
+- An example workflow for converting American English to British English
 
-- **[Write/Rephrase endpoint](/api-reference/improve-text)**: Rephrases text into the target language variant.
+---
 
-- **[Style rules](/api-reference/style-rules)**: Create a custom style rule and apply it using the [style_id](/api-reference/translate/request-translation#body-style-id) parameter.
+## Methods for translating between variants
 
-<Info>Both glossaries and style rules are unique to each of DeepL's global data centers and are not shared between them. Clients using the api-us.deepl.com endpoint will not be able to access glossaries or style rules created in the UI at this time.</Info>
+You can use the DeepL API to translate between variants of the same language using 3 methods:
 
-- **[Custom instructions](/api-reference/translate/request-translation#body-custom-instructions)**: Add instructions like "translate to British English" to your `/translate` request. You can specify up to 10 custom instructions, each with a maximum of 300 characters.
+### 1. DeepL Write API
 
-## Example: Converting American English to British English
+Use the [/write/rephrase](/api-reference/improve-text) endpoint to rephrase text into the target language variant.
 
-``` Example request
-curl -X POST 'https://api.deepl.com/v2/translate' \
---header 'Content-Type: application/json' \
+**When to use this:**
+- You're translating shorter texts (headlines, product names, brief descriptions)
+- You want high-quality rephrasing alongside variant translation
+
+```bash Example cURL request
+curl -X POST 'https://api.deepl.com/v2/write/rephrase' \
 --header 'Authorization: DeepL-Auth-Key [yourAuthKey]' \
+--header 'Content-Type: application/json' \
 --data '{
-  "text": ["I went to the pharmacy to get some acetaminophen."],
+  "text": ["Check out the new fall colors!"],
+  "target_lang": "en-GB"
+}'
+```
+
+```json Example response
+{
+  "improvements": [
+    {
+      "text": "Check out the new autumn colours!",
+      "detected_source_language": "en",
+      "target_language": "en-GB"
+    }
+  ]
+}
+```
+
+<Warning>
+For longer texts, the Write API may rephrase and enhance content beyond simple variant conversion. If you need to maintain the exact structure while only updating locale-specific spelling and grammar, use another method.
+</Warning>
+
+### 2. Style rules with custom instructions
+
+Create a reusable [style rule](/api-reference/style-rules) with attached `custom_instructions` describing the desired variant translation.
+
+**When to use this:**
+- You need to maintain the text's content between variants as precisely as possible
+- You need consistent variant transformations across many translation requests
+- You want to reuse the same variant rules without repeating the custom instructions
+
+```bash Example cURL request
+curl -X POST 'https://api.deepl.com/v2/translate' \
+--header 'Authorization: DeepL-Auth-Key [yourAuthKey]' \
+--header 'Content-Type: application/json' \
+--data '{
+  "text": ["I went to the pharmacy."],
   "target_lang": "en-GB",
-  "model_type": "quality_optimized",
-  "custom_instructions": ["translate to British English", "only replace words that would be different"]
+  "style_id": "your-style-rule-id"
 }'
 ```
 
@@ -33,12 +74,59 @@ curl -X POST 'https://api.deepl.com/v2/translate' \
   "translations": [
     {
       "detected_source_language": "EN",
-      "text": "I went to the chemist to get some paracetamol.",
-      "model_type_used": "quality_optimized"
+      "text": "I went to the chemist's."
     }
   ]
 }
 ```
 
-<Tip>The custom instructions convert American English terms ("pharmacy", "acetaminophen") to British English equivalents ("chemist", "paracetamol") while preserving sentence structure.</Tip>
+<Info>
+Glossaries and style rules are unique to each of DeepL's global data centers and are not shared between them.
+
+Clients using the `api-us.deepl.com` endpoint will not be able to access glossaries or style rules created in the UI at this time.
+</Info>
+
+### 3. Per-request custom instructions
+
+Add [custom_instructions](/api-reference/translate/request-translation#body-custom-instructions) describing the desired variant translation directly into your `/translate` requests.
+
+**When to use this:**
+- You need to maintain the text's content between variants as precisely as possible
+- You need ad-hoc, one-off translations with specific variant requirements
+- You don't want to manage separate style rules
+
+```bash Example cURL request
+curl -X POST 'https://api.deepl.com/v2/translate' \
+--header 'Authorization: DeepL-Auth-Key [yourAuthKey]' \
+--header 'Content-Type: application/json' \
+--data '{
+  "text": ["I went to the pharmacy."],
+  "target_lang": "en-GB",
+  "custom_instructions": ["translate to British English"]
+}'
+```
+
+```json Example response
+{
+  "translations": [
+    {
+      "detected_source_language": "EN",
+      "text": "I went to the chemist's."
+    }
+  ]
+}
+```
+
+You can specify up to 10 custom instructions per request, each with a maximum of 300 characters.
+
+---
+
+## Next steps
+
+Now that you understand how to translate between language variants:
+
+- **Try it yourself:** Test out style rules and custom instructions in the [text translation API playground](/api-reference/translate)
+- **Learn about the Write API:** Explore the [/write/rephrase endpoint](/api-reference/improve-text) for high-quality variant translation and rephrasing
+- **Manage reusable rules:** Learn how to create [style rules](/api-reference/style-rules) for systematic variant transformations
+- **Improve translation quality:** Understand how [the context parameter](/docs/best-practices/working-with-context) can enhance ambiguous translations
 


### PR DESCRIPTION
This is a variant of the guide based on the [Diataxis content model](https://diataxis.fr/how-to-guides/) for presenting the information