### PR TITLE
fix: update response body for languages endpt

### DIFF
--- a/api-reference/openapi.yaml
+++ b/api-reference/openapi.yaml
@@ -1858,118 +1858,70 @@ paths:
               example:
                 - language: AR
                   name: Arabic
-                  supports_formality: false
                 - language: BG
                   name: Bulgarian
-                  supports_formality: false
                 - language: CS
                   name: Czech
-                  supports_formality: false
                 - language: DA
                   name: Danish
-                  supports_formality: false
                 - language: DE
                   name: German
-                  supports_formality: true
                 - language: EL
                   name: Greek
-                  supports_formality: false
-                - language: EN-GB
-                  name: English (British)
-                  supports_formality: false
-                - language: EN-US
-                  name: English (American)
-                  supports_formality: false
+                - language: EN
+                  name: English
                 - language: ES
                   name: Spanish
-                  supports_formality: true
-                - language: ES-419
-                  name: Spanish
-                  supports_formality: true
                 - language: ET
                   name: Estonian
-                  supports_formality: false
                 - language: FI
                   name: Finnish
-                  supports_formality: false
                 - language: FR
                   name: French
-                  supports_formality: true
                 - language: HE
                   name: Hebrew
-                  supports_formality: false
                 - language: HU
                   name: Hungarian
-                  supports_formality: false
                 - language: ID
                   name: Indonesian
-                  supports_formality: false
                 - language: IT
                   name: Italian
-                  supports_formality: true
                 - language: JA
                   name: Japanese
-                  supports_formality: true
                 - language: KO
                   name: Korean
-                  supports_formality: false
                 - language: LT
                   name: Lithuanian
-                  supports_formality: false
                 - language: LV
                   name: Latvian
-                  supports_formality: false
                 - language: NB
-                  name: Norwegian (Bokmål)
-                  supports_formality: false
+                  name: Norwegian
                 - language: NL
                   name: Dutch
-                  supports_formality: true
                 - language: PL
                   name: Polish
-                  supports_formality: true
-                - language: PT-BR
-                  name: Portuguese (Brazilian)
-                  supports_formality: true
-                - language: PT-PT
-                  name: Portuguese (European)
-                  supports_formality: true
+                - language: PT
+                  name: Portuguese
                 - language: RO
                   name: Romanian
-                  supports_formality: false
                 - language: RU
                   name: Russian
-                  supports_formality: true
                 - language: SK
                   name: Slovak
-                  supports_formality: false
                 - language: SL
                   name: Slovenian
-                  supports_formality: false
                 - language: SV
                   name: Swedish
-                  supports_formality: false
                 - language: TH
                   name: Thai
-                  supports_formality: false
                 - language: TR
                   name: Turkish
-                  supports_formality: false
                 - language: UK
                   name: Ukrainian
-                  supports_formality: false
                 - language: VI
                   name: Vietnamese
-                  supports_formality: false
                 - language: ZH
-                  name: Chinese (simplified)
-                  supports_formality: false
-                - language: ZH-HANS
-                  name: Chinese (simplified)
-                  supports_formality: false
-                - language: ZH-HANT
-                  name: Chinese (traditional)
-                  supports_formality: false
+                  name: Chinese
         400:
           $ref: '#/components/responses/BadRequest'
         403:


### PR DESCRIPTION
There's an inconsistency in that we render the response body of `v2/languages?type=target` as an example of a successful request, but the example curl request displays `v2/languages?type=source` because `source` is the default value