### PR TITLE
Update API versions docs to reflect v1 access for API keys

### DIFF
--- a/docs/getting-started/auth.mdx
+++ b/docs/getting-started/auth.mdx
@@ -39,4 +39,6 @@ The authentication key is provided by setting the *Authorization* HTTP header to
 
 The current API version is v2, meaning that all request paths start with `/v2/`.
 
-It is the only supported version, with the exception of CAT tool integrations, which need to use the version 1 API that is not documented here. If you intend to integrate DeepL Pro into a CAT tool or another tool assisting translation, please contact [cat-tool.support@DeepL.com](mailto:cat-tool.support@DeepL.com).
+The version 1 API (`/v1/`) is also available for both API and CAT tool authentication keys. It supports the `/v1/translate`, `/v1/languages`, `/v1/usage`, and `/v1/glossaries` endpoints. The v1 and v2 endpoints share the same underlying implementation. Usage is reported and billed normally for API keys accessing v1 endpoints.
+
+If you intend to integrate DeepL Pro into a CAT tool or another tool assisting translation, please contact [cat-tool.support@DeepL.com](mailto:cat-tool.support@DeepL.com).


### PR DESCRIPTION
## Summary

- Updated the "API Versions" section in `docs/getting-started/auth.mdx` to reflect that v1 API endpoints are now accessible with both API and CAT tool authentication keys
- Listed available v1 endpoints: `/v1/translate`, `/v1/languages`, `/v1/usage`, `/v1/glossaries`
- Clarified that v1 and v2 share the same implementation and usage is billed normally
- Preserved the CAT tool support contact info

## Context

- Jira: [BET-3572](https://deepl.atlassian.net/browse/BET-3572)
- Related: [PART-211](https://deepl.atlassian.net/browse/PART-211) (Enable v1 access for API subscriptions)
- v1 access for API keys was released on Feb 9, 2026

🤖 Generated with [Claude Code](https://claude.com/claude-code)