### PR TITLE
Remove broken link to context guide

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -65,7 +65,6 @@
               {
                 "group": "Guides",
                 "pages": [
-                  "docs/learning-how-tos/examples-and-guides/",
                   "docs/learning-how-tos/examples-and-guides/how-to-use-context-parameter",
                   "docs/learning-how-tos/examples-and-guides/placeholder-tags",
                   "docs/learning-how-tos/examples-and-guides/first-things-to-try-with-the-deepl-api",

--- a/docs/learning-how-tos/cookbook.mdx
+++ b/docs/learning-how-tos/cookbook.mdx
@@ -11,24 +11,19 @@ public: true
 
     Updated on 2025-03-12
   </Card>
-  <Card title="Context Parameter Examples" icon="braille" href="/docs/learning-how-tos/cookbook/context-parameter-examples">
-    Written by [Michael Winters](https://github.com/mike-winters-deepl) and [Paul Gordon](https://github.com/pgdev)
-
-    Updated on 2025-03-12
-  </Card>
   <Card title="Using the DeepL API and Godot to localize indie games" icon="gamepad-modern" href="/docs/learning-how-tos/cookbook/automating-indie-game-localization-with-the-deepl-api-and-godot">
     Written by Lucas Mathis
 
     Updated on 2024-04-10
   </Card>
-</CardGroup>
-
-<CardGroup cols={3}>
   <Card title="Building a Document Translator with the DeepL API" icon="file" href="/docs/learning-how-tos/cookbook/java-document-translator">
     Written by [Akash Joshi](https://thewriting.dev)
 
     Updated on 2025-07-03
   </Card>
+</CardGroup>
+
+<CardGroup cols={3}>
   <Card title="Usage Analytics Dashboard" icon="chart-line" href="/docs/learning-how-tos/cookbook/usage-analytics-dashboard">
     A demo dashboard for visualizing API usage across your entire account
 


### PR DESCRIPTION
Also removes a missing page from the guides area. Maybe we should re-add an overview page to the guides?

<!-- mintlify-editor-comments:start -->
Mintlify
---
0 threads from 0 users in Mintlify

- No unresolved comments
<!-- mintlify-editor-comments:end -->