### PR TITLE
Update API versions docs to reflect v1 access for API keys

### DIFF
--- a/docs/getting-started/auth.mdx
+++ b/docs/getting-started/auth.mdx
@@ -37,6 +37,8 @@ The authentication key is provided by setting the *Authorization* HTTP header to
 
 #### API Versions
 
-The current API version is v2, meaning that all request paths start with `/v2/`.
+The primary API version is v2, meaning that most request paths start with `/v2/`. Some endpoints are also available under `/v3/` — see [v2 vs v3 glossary endpoints](/api-reference/glossaries/v2-vs-v3-endpoints) for details.
 
-It is the only supported version, with the exception of CAT tool integrations, which need to use the version 1 API that is not documented here. If you intend to integrate DeepL Pro into a CAT tool or another tool assisting translation, please contact [cat-tool.support@DeepL.com](mailto:cat-tool.support@DeepL.com).
+The previous version of the API (`/v1/`) is also available for compatibility reasons and matches v2 functionality. Usage is reported and billed normally when accessing v1 endpoints.
+
+If you intend to integrate DeepL Pro into a CAT tool or another tool assisting translation, please contact [cat-tool.support@DeepL.com](mailto:cat-tool.support@DeepL.com).


### PR DESCRIPTION
## Summary

- Updated the "API Versions" section in `docs/getting-started/auth.mdx` to reflect that v1 API endpoints are now accessible with any API authentication key (not just CAT tool keys)
- Clarified that v1 matches v2 functionality and usage is reported and billed normally