### PR TITLE
Use wide mode for articles with few or no section heads

### DIFF
--- a/docs/best-practices/cors-requests.mdx
+++ b/docs/best-practices/cors-requests.mdx
@@ -1,5 +1,6 @@
 ---
 title: "CORS requests"
+mode: "wide"
 public: true
 ---
 

--- a/docs/best-practices/cost-control.mdx
+++ b/docs/best-practices/cost-control.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Subscription-level cost control"
+mode: "wide"
 public: true
 ---
 

--- a/docs/best-practices/document-translations.mdx
+++ b/docs/best-practices/document-translations.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Document translations"
+mode: "wide"
 public: true
 ---
 

--- a/docs/best-practices/error-handling.mdx
+++ b/docs/best-practices/error-handling.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Error handling"
+mode: "wide"
 public: true
 ---
 

--- a/docs/best-practices/language-detection.mdx
+++ b/docs/best-practices/language-detection.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Language detection"
+mode: "wide"
 public: true
 ---
 

--- a/docs/best-practices/pre-production-checklist.mdx
+++ b/docs/best-practices/pre-production-checklist.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Pre-production checklist"
 description: "Here's what we recommend reviewing to get your DeepL API application ready for production."
+mode: "wide"
 public: true
 ---
 As you prepare to open your DeepL-powered application up to the world, these tips will help you get ready for production.

--- a/docs/getting-started/about.mdx
+++ b/docs/getting-started/about.mdx
@@ -1,6 +1,7 @@
 ---
 title: "About"
 public: false
+mode: "wide"
 ---
 
 <Info>

--- a/docs/getting-started/auth.mdx
+++ b/docs/getting-started/auth.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Access and authentication"
 description: "Learn where to find your authentication key and how to access the DeepL API."
+mode: "wide"
 public: true
 ---
 

--- a/docs/getting-started/client-libraries.mdx
+++ b/docs/getting-started/client-libraries.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Client libraries"
 public: true
+mode: "wide"
 ---
 ## Official client libraries
 

--- a/docs/getting-started/test-your-api-requests-with-postman.mdx
+++ b/docs/getting-started/test-your-api-requests-with-postman.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Test your API requests with Postman"
 description: "Use our official Postman collection to get familiar with and test the DeepL API."
+mode: "wide"
 public: true
 ---
 

--- a/docs/resources/alpha-and-beta-features.mdx
+++ b/docs/resources/alpha-and-beta-features.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Alpha and beta features"
 description: "Learn more about alpha and beta features in the DeepL API and how to best make use of them."
+mode: "wide"
 public: true
 ---
 

--- a/docs/resources/breaking-changes-change-notices.mdx
+++ b/docs/resources/breaking-changes-change-notices.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Breaking changes (Change Notices)"
 sidebarTitle: "Overview"
+mode: "wide"
 ---
 
 In this section, we'll outline **planned deprecations and breaking changes** that might affect applications using the DeepL API.

--- a/docs/resources/deepl-developer-community.mdx
+++ b/docs/resources/deepl-developer-community.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Developer Community"
+mode: "wide"
 ---
 
 ![graphic for DeepL Bridges](https://tribe-eu.imgix.net/uU2Ee5IedtSmeFhLPfa2a?fit=max&w=1000&auto=compress,format)

--- a/docs/resources/language-release-process.mdx
+++ b/docs/resources/language-release-process.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Language release process"
 description: "Here's what API users can expect when DeepL adds translation support for a new language or language variant."
+mode: "wide"
 ---
 
 On a regular basis, DeepL adds translation support for new languages or language variants. In this article, we describe the process we'll follow with a new language or variant release.

--- a/docs/xml-and-html-handling/customized-xml-outline-detection.mdx
+++ b/docs/xml-and-html-handling/customized-xml-outline-detection.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Customized XML outline detection"
 description: "Learn how to customize XML outline detection with the DeepL API."
+mode: "wide"
 ---
 
 Automatic detection of the XML structure will not always yield the best results in all XML files. You can disable this automatic mechanism by setting the `outline_detection=0` and selecting the tags that should be considered structure tags. This will split sentences using the `splitting_tags` parameter.


### PR DESCRIPTION
Unless those section heads seem to be useful ways of navigating the article in question!

Otherwise, at medium window widths, we're just unnecessarily restricting the amount of information shown.