### PR TITLE
fix: Use "style rule list" terminology consistently

### DIFF
--- a/api-reference/openapi.yaml
+++ b/api-reference/openapi.yaml
@@ -2521,7 +2521,7 @@ paths:
       security:
       - auth_header: []
     patch:
-      summary: Update a style rule list
+      summary: Update a style rule list's name
       operationId: updateStyleRuleList
       parameters:
         - name: style_id
@@ -4481,19 +4481,19 @@ components:
         name:
           $ref: '#/components/schemas/StyleRuleName'
         creation_time:
-          description: 'The creation time of the style rule in the ISO 8601-1:2019 format
+          description: 'The creation time of the style rule list in the ISO 8601-1:2019 format
             (e.g.: `2021-08-03T14:16:18.329Z`).'
           type: string
           format: date-time
         updated_time:
-          description: 'The time of the style rule when it was last updated in the ISO 8601-1:2019 format
+          description: 'The time of the style rule list when it was last updated in the ISO 8601-1:2019 format
             (e.g.: `2022-08-03T14:16:18.329Z`).'
           type: string
           format: date-time
         language:
           $ref: '#/components/schemas/StyleRuleLanguage'
         version:
-          description: The version of the style rule. Incremented when the style rule is updated.
+          description: The version of the style rule list. Incremented when the style rule list is updated.
           type: integer
           example: 13
         configured_rules:
@@ -4506,10 +4506,10 @@ components:
             $ref: '#/components/schemas/CustomInstruction'
     StyleId:
       type: string
-      description: A unique ID assigned to a style rule.
+      description: A unique ID assigned to a style rule list.
       example: "bd0a38f3-1831-440b-a8dd-2c702e2325ab"
     StyleRuleLanguage:
-      description: The language that the style rules are applied to.
+      description: The language that the style rule list is applied to.
       type: string
       enum:
       - de
@@ -4521,7 +4521,7 @@ components:
       - ko
       - zh
     StyleRuleName:
-      description: Name associated with the style rule.
+      description: Name associated with the style rule list.
       type: string
     DocumentTranslationError:
       type: object

--- a/api-reference/style-rules.mdx
+++ b/api-reference/style-rules.mdx
@@ -408,7 +408,7 @@ Get detailed information for a single style rule list, including all configured 
 
 Use `PATCH /v3/style_rules/{style_id}` to update the name of a style rule list, or use `PUT /v3/style_rules/{style_id}/configured_rules` to replace all configured rules.
 
-### Update a style rule list
+### Update a style rule list's name
 
 `PATCH /v3/style_rules/{style_id}`
 
@@ -418,7 +418,7 @@ Update the name of a style rule list.
   <Tab title="cURL">
     The example below uses our API Pro endpoint `https://api.deepl.com`. If you're an API Free user, remember to update your requests to use `https://api-free.deepl.com` instead.
 
-    ```sh Example request: update a style rule list
+    ```sh Example request: update a style rule list's name
     curl -X PATCH 'https://api.deepl.com/v3/style_rules/{style_id}' \
     --header 'Authorization: DeepL-Auth-Key [yourAuthKey]' \
     --header 'Content-Type: application/json' \
@@ -457,7 +457,7 @@ Update the name of a style rule list.
   <Tab title="HTTP Request">
     The example below uses our API Pro endpoint `https://api.deepl.com`. If you're an API Free user, remember to update your requests to use `https://api-free.deepl.com` instead.
 
-    ```http Example request: update a style rule list
+    ```http Example request: update a style rule list's name
     PATCH /v3/style_rules/{style_id} HTTP/2
     Host: api.deepl.com
     Authorization: DeepL-Auth-Key [yourAuthKey]

--- a/api-reference/style-rules/update-style-rule.mdx
+++ b/api-reference/style-rules/update-style-rule.mdx
@@ -1,4 +1,4 @@
 ---
 openapi: patch /v3/style_rules/{style_id}
-title: "Update a style rule list"
+title: "Update a style rule list's name"
 ---

--- a/docs/learning-how-tos/examples-and-guides/translating-between-variants.mdx
+++ b/docs/learning-how-tos/examples-and-guides/translating-between-variants.mdx
@@ -53,7 +53,7 @@ Please note that currently, the methods outlined below are not fully supported f
 
 ### 2. Style rules with custom instructions
 
-Create a reusable [style rule](/api-reference/style-rules) with attached `custom_instructions` describing the desired variant translation.
+Create a reusable [style rule list](/api-reference/style-rules) with attached `custom_instructions` describing the desired variant translation.
 
 **When to use this:**
 - You need to maintain the text's content between variants as precisely as possible


### PR DESCRIPTION
Descriptions in the StyleRuleList schema and related sub-schemas incorrectly referred to "style rule" when the entity is a style rule list. Also renamed the PATCH endpoint to clarify it updates the list's name.