### PR TITLE
Document that texts in array are translated independently

### DIFF
--- a/api-reference/openapi.yaml
+++ b/api-reference/openapi.yaml
@@ -405,7 +405,8 @@ paths:
                   description: |-
                     Text to be translated. Only UTF-8-encoded plain text is supported. The parameter may be specified
                     many times in a single request, within the request size limit (128KiB). Translations are returned
-                    in the same order as they are requested.
+                    in the same order as they are requested. Each text in the array is translated independently — texts
+                    do not share context with each other.
                   type: array
                   items:
                     type: string
@@ -496,7 +497,8 @@ paths:
                 text:
                   description: Text to be translated. Only UTF-8-encoded plain text is supported. The parameter may be
                     specified many times in a single request, within the request size limit (128KiB). Translations are
-                    returned in the same order as they are requested.
+                    returned in the same order as they are requested. Each text in the array is translated independently
+                    — texts do not share context with each other.
                   type: array
                   items:
                     type: string

--- a/api-reference/translate.mdx
+++ b/api-reference/translate.mdx
@@ -180,7 +180,7 @@ Note that we do not include examples for our client libraries in every single se
   Text to be translated. Only UTF-8-encoded plain text is supported. The parameter may be specified multiple times and translations are returned in the same order as they are requested. Each of the parameter values may contain multiple sentences. Up to 50 texts can be sent for translation in one request.
 
   <Warning>
-    Each text in the array is translated independently — texts do not share context with each other. If one text provides context that would help translate another (e.g. a headline and its article body), either combine them into a single text or use the <code>context</code> parameter to provide shared context.
+    Each text in the array is translated independently — texts do not share context with each other. If one text provides context that would help translate another (e.g. a headline and its article body), either combine them into a single text or use the <a href="#request-body-descriptions"><code>context</code></a> parameter to provide shared context.
   </Warning>
 </ParamField>
 <ParamField body="source_lang" type="string">
@@ -206,6 +206,8 @@ Note that we do not include examples for our client libraries in every single se
   <p>If you send a request with multiple <code>text</code> parameters, the <code>context</code> parameter will be applied to each one.</p>
 
   <p>Characters included in the <code>context</code> parameter will not be counted toward billing (i.e., there is no additional cost for using the <code>context</code> parameter, and only characters sent in the <code>text</code> parameter(s) will be counted toward billing for text translation even when the <code>context</code> parameter is included in a request).</p>
+
+  <p>See <a href="/docs/learning-how-tos/examples-and-guides/how-to-use-context-parameter">How to Use the Context Parameter Effectively</a> for examples and best practices.</p>
 </ParamField>
 <ParamField body="model_type" type="enum">
   Specifies which DeepL model should be used for translation.

--- a/api-reference/translate.mdx
+++ b/api-reference/translate.mdx
@@ -178,6 +178,10 @@ Note that we do not include examples for our client libraries in every single se
 
 <ParamField body="text" type="array[string]" required>
   Text to be translated. Only UTF-8-encoded plain text is supported. The parameter may be specified multiple times and translations are returned in the same order as they are requested. Each of the parameter values may contain multiple sentences. Up to 50 texts can be sent for translation in one request.
+
+  <Warning>
+    Each text in the array is translated independently — texts do not share context with each other. If one text provides context that would help translate another (e.g. a headline and its article body), either combine them into a single text or use the <code>context</code> parameter to provide shared context.
+  </Warning>
 </ParamField>
 <ParamField body="source_lang" type="string">
   Language of the text to be translated. If omitted, the API will attempt to detect the language of the text and translate it. You can find supported source languages <a href="/docs/getting-started/supported-languages#translation-source-languages">here</a>.

--- a/docs/learning-how-tos/examples-and-guides/how-to-use-context-parameter.mdx
+++ b/docs/learning-how-tos/examples-and-guides/how-to-use-context-parameter.mdx
@@ -153,7 +153,7 @@ When translating names in headlines or short snippets, the same name might be tr
 
 ### Example
 
-Content is not shared between `text` parameters. This results in different transliterations for the name "Sergej".
+As noted in the [`text` field reference](/api-reference/translate#request-body-descriptions), each text in the array is translated independently and texts do not share context with each other. This results in different transliterations for the name "Sergej".
 
 ```sh
 curl -X POST 'https://api.deepl.com/v2/translate' \
@@ -253,7 +253,7 @@ There is no size limit for the `context` parameter itself, but the request body 
 
 ### Multi-`text` requests
 
-Content is not shared between multiple `text` parameters sent in one request. Each text parameter is translated independently.
+As noted in the [`text` field reference](/api-reference/translate#request-body-descriptions), each text in the array is translated independently — they do not share context with each other.
 
 In this example, "Tor" might be translated as "gate" instead of "goal" because the first `text` doesn't have access to the second one's content.
 


### PR DESCRIPTION
## Summary
- Added a **Warning** callout to the `text` field definition in the translate API reference, making it immediately clear that each text in the array is translated independently without shared context
- Updated the OpenAPI spec (`openapi.yaml`) with the same information in both JSON and form-encoded `text` field descriptions
- Updated the context parameter guide to reference the field definition instead of restating the behavior in isolation

## Motivation
The fact that texts don't share context is critical for correct API usage (e.g. translating headlines alongside article bodies). Previously this was only documented in the "How to Use Context" guide, far from where developers first encounter the `text` field.

## Test plan
- [ ] Preview the translate API reference page and verify the Warning renders correctly under the `text` field
- [ ] Preview the context parameter guide and verify the links to the field reference resolve correctly


🤖 Generated with [Claude Code](https://claude.com/claude-code)