### PR TITLE
Pass account id to customer research signup

### DIFF
--- a/user-data.js
+++ b/user-data.js
@@ -6,6 +6,17 @@ window.DeepLUser = (() => {
   const API_PARAMS = 'request_type=jsonrpc&il=en&method=getClientState';
   const apiUrl = `${API_BASE_URL}?${API_PARAMS}`;
 
+  function extractAccountId(apiSubscription) {
+    if (!apiSubscription) return undefined;
+
+    return (
+      apiSubscription.accountId
+      || apiSubscription.accountID
+      || apiSubscription.account_id
+      || apiSubscription.account?.id
+    );
+  }
+
   /* Following the standards of deepl.com, we place the request parameters in both the URL and the body,
    * although this may not be necessary.
    * TODO: Complete error handling, for cases when the user is not logged in, there is no user, etc.
@@ -37,5 +48,10 @@ window.DeepLUser = (() => {
     }
   }
 
-  return { getApiSubscription };
+  async function getAccountId() {
+    const apiSubscription = await getApiSubscription();
+    return extractAccountId(apiSubscription);
+  }
+
+  return { getApiSubscription, getAccountId };
 })();

--- a/user-study-popup.js
+++ b/user-study-popup.js
@@ -121,6 +121,15 @@
   }
 
   window.getUserStudySignupUrlNow = getSignupUrl;
+  window.showUserStudyPopupNow = function showUserStudyPopupNow() {
+    localStorage.removeItem(USER_STUDY_KEY);
+
+    if (!hasResolvedCookieBanner()) {
+      localStorage.setItem(CONSENT_KEY, CONSENT_ACCEPTED);
+    }
+
+    renderPopup();
+  };
 
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', initUserStudyPopup);

--- a/user-study-popup.js
+++ b/user-study-popup.js
@@ -10,6 +10,26 @@
   const INITIAL_DELAY_MS = 2000;
   const RETRY_DELAY_MS = 1000;
 
+  function buildSignupUrl(accountId) {
+    const signupUrl = new URL(SIGNUP_URL);
+
+    if (accountId) {
+      signupUrl.searchParams.set('acc_id', accountId);
+    }
+
+    return signupUrl.toString();
+  }
+
+  async function getSignupUrl() {
+    try {
+      const accountId = await window.DeepLUser?.getAccountId?.();
+      return buildSignupUrl(accountId);
+    } catch (error) {
+      console.error('Error building customer research signup URL:', error);
+      return buildSignupUrl();
+    }
+  }
+
   function hasResolvedCookieBanner() {
     const consent = localStorage.getItem(CONSENT_KEY);
     return consent === CONSENT_ACCEPTED || consent === CONSENT_REJECTED;
@@ -39,6 +59,8 @@
   function renderPopup() {
     if (document.getElementById('user-study-popup')) return;
 
+    const signupUrlPromise = getSignupUrl();
+
     const popup = document.createElement('div');
     popup.id = 'user-study-popup';
     popup.innerHTML = `
@@ -57,6 +79,10 @@
 
     document.body.appendChild(popup);
 
+    signupUrlPromise.then((signupUrl) => {
+      popup.querySelector('#user-study-cta')?.setAttribute('href', signupUrl);
+    });
+
     window.setTimeout(() => {
       popup.querySelector('#user-study-card')?.classList.add('slide-in');
     }, 50);
@@ -66,9 +92,14 @@
       removePopup(popup);
     });
 
-    popup.querySelector('#user-study-cta')?.addEventListener('click', () => {
+    popup.querySelector('#user-study-cta')?.addEventListener('click', async (event) => {
+      event.preventDefault();
+
       markPopupState(USER_STUDY_CLICKED);
       removePopup(popup);
+
+      const signupUrl = await signupUrlPromise;
+      window.open(signupUrl, '_blank', 'noopener,noreferrer');
     });
   }
 
@@ -88,6 +119,8 @@
   function initUserStudyPopup() {
     window.setTimeout(maybeShowUserStudyPopup, INITIAL_DELAY_MS);
   }
+
+  window.getUserStudySignupUrlNow = getSignupUrl;
 
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', initUserStudyPopup);


### PR DESCRIPTION
## Summary
- extend `user-data.js` with a focused account id helper built on the existing user-service request
- append `acc_id` to the Ethnio customer research signup URL when an account id is available
- only fetch user data when the popup is actually shown

## Testing
- Due to CORS, this can only be fully tested on prod
- On prod, in the browser console:
   - run `await window.getUserStudySignupUrlNow()` to inspect the final signup URL
   - run `window.showUserStudyPopupNow()` to get the actual popup
- for logged-in users with account data available, the URL should look like `https://deepl.ethn.io/177614?acc_id=...`
- if account data is unavailable, the popup should still fall back to the base Ethnio URL

## Cleanup
- In another PR, we will remove the temporary `window.getUserStudySignupUrlNow` helper after review/testing is complete