### PR TITLE
Read account id from full client state

### DIFF
--- a/user-data.js
+++ b/user-data.js
@@ -5,34 +5,6 @@ window.DeepLUser = (() => {
   const API_BASE_URL = 'https://w.deepl.com/web';
   const API_PARAMS = 'request_type=jsonrpc&il=en&method=getClientState';
   const apiUrl = `${API_BASE_URL}?${API_PARAMS}`;
-  const ACCOUNT_ID_KEYS = ['accountId', 'accountID', 'account_id'];
-
-  function findValueByKeys(value, keys) {
-    if (!value || typeof value !== 'object') return undefined;
-
-    for (const key of keys) {
-      if (value[key] !== undefined && value[key] !== null) {
-        return value[key];
-      }
-    }
-
-    for (const nestedValue of Object.values(value)) {
-      const match = findValueByKeys(nestedValue, keys);
-      if (match !== undefined) return match;
-    }
-
-    return undefined;
-  }
-
-  function extractAccountId(clientState) {
-    if (!clientState) return undefined;
-
-    return (
-      findValueByKeys(clientState, ACCOUNT_ID_KEYS)
-      || clientState.account?.id
-      || clientState.subscription?.account?.id
-    );
-  }
 
   /* Following the standards of deepl.com, we place the request parameters in both the URL and the body,
    * although this may not be necessary.
@@ -72,8 +44,12 @@ window.DeepLUser = (() => {
 
   async function getAccountId() {
     const clientState = await getClientState();
-    return extractAccountId(clientState);
+    return clientState?.accountId;
   }
 
   return { getClientState, getApiSubscription, getAccountId };
 })();
+
+window.getDeepLClientStateNow = function getDeepLClientStateNow() {
+  return window.DeepLUser?.getClientState?.();
+};

--- a/user-data.js
+++ b/user-data.js
@@ -44,7 +44,7 @@ window.DeepLUser = (() => {
 
   async function getAccountId() {
     const clientState = await getClientState();
-    return clientState?.accountId;
+    return clientState?.loginState?.accountId;
   }
 
   return { getClientState, getApiSubscription, getAccountId };

--- a/user-data.js
+++ b/user-data.js
@@ -1,15 +1,8 @@
-/* Encapsulate user-data helpers in a single namespace to avoid polluting
- * the global scope. Other scripts can call DeepLUser helpers.
- */
+/* Expose the minimal client-state helpers needed by the docs popup. */
 window.DeepLUser = (() => {
   const API_BASE_URL = 'https://w.deepl.com/web';
   const API_PARAMS = 'request_type=jsonrpc&il=en&method=getClientState';
   const apiUrl = `${API_BASE_URL}?${API_PARAMS}`;
-
-  /* Following the standards of deepl.com, we place the request parameters in both the URL and the body,
-   * although this may not be necessary.
-   * TODO: Complete error handling, for cases when the user is not logged in, there is no user, etc.
-   */
 
   async function getClientState() {
     try {
@@ -47,7 +40,7 @@ window.DeepLUser = (() => {
     return clientState?.loginState?.accountId;
   }
 
-  return { getClientState, getApiSubscription, getAccountId };
+  return { getClientState, getAccountId };
 })();
 
 window.getDeepLClientStateNow = function getDeepLClientStateNow() {

--- a/user-data.js
+++ b/user-data.js
@@ -1,19 +1,36 @@
 /* Encapsulate user-data helpers in a single namespace to avoid polluting
- * the global scope. Other scripts can call DeepLUser.getApiSubscription().
+ * the global scope. Other scripts can call DeepLUser helpers.
  */
 window.DeepLUser = (() => {
   const API_BASE_URL = 'https://w.deepl.com/web';
   const API_PARAMS = 'request_type=jsonrpc&il=en&method=getClientState';
   const apiUrl = `${API_BASE_URL}?${API_PARAMS}`;
+  const ACCOUNT_ID_KEYS = ['accountId', 'accountID', 'account_id'];
 
-  function extractAccountId(apiSubscription) {
-    if (!apiSubscription) return undefined;
+  function findValueByKeys(value, keys) {
+    if (!value || typeof value !== 'object') return undefined;
+
+    for (const key of keys) {
+      if (value[key] !== undefined && value[key] !== null) {
+        return value[key];
+      }
+    }
+
+    for (const nestedValue of Object.values(value)) {
+      const match = findValueByKeys(nestedValue, keys);
+      if (match !== undefined) return match;
+    }
+
+    return undefined;
+  }
+
+  function extractAccountId(clientState) {
+    if (!clientState) return undefined;
 
     return (
-      apiSubscription.accountId
-      || apiSubscription.accountID
-      || apiSubscription.account_id
-      || apiSubscription.account?.id
+      findValueByKeys(clientState, ACCOUNT_ID_KEYS)
+      || clientState.account?.id
+      || clientState.subscription?.account?.id
     );
   }
 
@@ -22,7 +39,7 @@ window.DeepLUser = (() => {
    * TODO: Complete error handling, for cases when the user is not logged in, there is no user, etc.
    */
 
-  async function getApiSubscription() {
+  async function getClientState() {
     try {
       const response = await fetch(
         apiUrl,
@@ -41,17 +58,22 @@ window.DeepLUser = (() => {
       );
       const json = await response.json();
 
-      return json?.result?.featureSet?.subscription?.api;
+      return json?.result;
 
     } catch (error) {
       console.error('Error fetching user data:', error);
     }
   }
 
-  async function getAccountId() {
-    const apiSubscription = await getApiSubscription();
-    return extractAccountId(apiSubscription);
+  async function getApiSubscription() {
+    const clientState = await getClientState();
+    return clientState?.featureSet?.subscription?.api;
   }
 
-  return { getApiSubscription, getAccountId };
+  async function getAccountId() {
+    const clientState = await getClientState();
+    return extractAccountId(clientState);
+  }
+
+  return { getClientState, getApiSubscription, getAccountId };
 })();


### PR DESCRIPTION
## Summary
- fix `user-data.js` so account id is derived from the full `getClientState` response instead of the boolean API subscription flag
- preserve the existing `acc_id` signup URL wiring in the customer research popup
- keep the current temporary testing helpers unchanged

## Testing
- this can only be verified in prod due to the existing CORS limitation on the user service request
- in prod, `await DeepLUser.getAccountId()` should return an account id for logged-in users
- in prod, `await window.getUserStudySignupUrlNow()` should return `https://deepl.ethn.io/177614?acc_id=...`