### PR TITLE
fix: several broken in page links were broken

### DIFF
--- a/api-reference/document.mdx
+++ b/api-reference/document.mdx
@@ -119,7 +119,7 @@ These examples are for demonstration purposes only. In production code, the auth
 
 #### Request Body Descriptions
 
-**Note:** the `model_type` parameter is not supported for API document translation and is only supported for [text translation](/api-reference/translate#about-the-model-type-parameter). It’s possible to submit a document translation request that includes the parameter, but the parameter will be ignored and will not have an effect on translation results.
+**Note:** the `model_type` parameter is not supported for API document translation and is only supported for [text translation](/api-reference/translate#about-the-model_type-parameter). It’s possible to submit a document translation request that includes the parameter, but the parameter will be ignored and will not have an effect on translation results.
 
 <ParamField body="source_lang" type="string">
   Language of the text to be translated. If omitted, the API will attempt to detect the language of the text and translate it. You can find supported languages <a href="/docs/getting-started/supported-languages#translation-target-languages">here</a>.

--- a/api-reference/glossaries.mdx
+++ b/api-reference/glossaries.mdx
@@ -13,6 +13,8 @@ This page documents `v2` glossary endpoints, legacy endpoints that let you creat
 
 This page describes how to use the `v2` endpoints to work with _monolingual_ glossaries - glossaries that map phrases in one language to phrases in another language. If you're new to glossaries, we suggest you use `v3` instead. 
 
+### Create a glossary
+
 <Tabs>
 <Tab title="cURL">
 The example below uses our API Pro endpoint `https://api.deepl.com`. If you're an API Free user, remember to update your requests to use `https://api-free.deepl.com` instead.

--- a/api-reference/translate.mdx
+++ b/api-reference/translate.mdx
@@ -7,7 +7,7 @@ public: true
 
 The text-translation API currently consists of a single endpoint, `translate`, which is described below.
 
-For highest translation quality, we recommend using our next-gen models. For details, please see [here](/docs/api-reference/translate#about-the-model-type-parameter).
+For highest translation quality, we recommend using our next-gen models. For details, please see [here](/api-reference/translate#about-the-model_type-parameter).
 
 To learn more about context in DeepL API translations, see our [context parameter guide](/docs/learning-how-tos/examples-and-guides/how-to-use-context-parameter).
 
@@ -229,7 +229,7 @@ Note that we do not include examples for our client libraries in every single se
 error.
   </Info>
 
-  See [About the model_type parameter](#about-the-model-type-parameter) for more details.
+  See [About the model_type parameter](#about-the-model_type-parameter) for more details.
 </ParamField>
 <ParamField body="split_sentences" type="string">
   Sets whether the translation engine should first split the input into sentences. For text translations where <code>tag_handling</code> is not set to <code>html</code>, the default value is <code>1</code>, meaning the engine splits on punctuation and on newlines.


### PR DESCRIPTION
fix: several broken in page links were broken

  api-reference/translate.mdx
  - Line 10: Fixed path /docs/api-reference/translate#... → /api-reference/translate#...
  - Line 10: Fixed anchor #about-the-model-type-parameter → #about-the-model_type-parameter
  - Line 232: Fixed anchor #about-the-model-type-parameter → #about-the-model_type-parameter

  api-reference/document.mdx
  - Line 122: Fixed anchor #about-the-model-type-parameter → #about-the-model_type-parameter

  api-reference/glossaries.mdx
  - Added missing ### Create a glossary heading before the create examples (so the existing
  #create-a-glossary anchor link resolves)