### PR TITLE
docs: update Mintlify CLI references from mintlify to mint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,7 +183,7 @@ This runs editorial and Diataxis reviews in parallel, deduplicates findings, and
 
 ## Local Development
 
-    npm i -g mintlify
-    mintlify dev
+    npm i -g mint
+    mint dev
 
-After making changes, run `mintlify broken-links` and `mintlify broken-links --check-anchors` to verify links.
+After making changes, run `mint broken-links` and `mint broken-links --check-anchors` to verify links.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,16 @@ Run the following command at the root of your documentation (where docs.json is)
 mint dev
 ```
 
+### Migrating from the old `mintlify` CLI
+
+If you have the deprecated `mintlify` package installed, replace it with `mint`:
+
+```
+npm uninstall -g mintlify
+npm cache clean --force
+npm i -g mint
+```
+
 ### Publishing Changes
 
 Install our Github App to auto propagate changes from your repo to your deployment. Changes will be deployed to production automatically after pushing to the default branch. Find the link to install on your dashboard.

--- a/README.md
+++ b/README.md
@@ -4,16 +4,16 @@ This repo is home to the [DeepL Developer Docs](https://developers.deepl.com/).
 
 ## Development
 
-Install the [Mintlify CLI](https://www.npmjs.com/package/mintlify) to preview the documentation changes locally. To install, use the following command
+Install the [Mintlify CLI](https://www.npmjs.com/package/mint) to preview the documentation changes locally. To install, use the following command
 
 ```
-npm i -g mintlify
+npm i -g mint
 ```
 
 Run the following command at the root of your documentation (where docs.json is)
 
 ```
-mintlify dev
+mint dev
 ```
 
 ### Publishing Changes
@@ -22,7 +22,7 @@ Install our Github App to auto propagate changes from your repo to your deployme
 
 #### Troubleshooting
 
-- Mintlify dev isn't running - Run `mintlify install` it'll re-install dependencies.
+- Mint dev isn't running - Run `mint install` to re-install dependencies.
 - Page loads as a 404 - Make sure you are running in a folder with `docs.json`
 
 ## AI Workflow
@@ -78,7 +78,7 @@ Use the docs-review agent on [filename]
 
 **Check for broken links:**
 ```
-mintlify broken-links
-mintlify broken-links --check-anchors
+mint broken-links
+mint broken-links --check-anchors
 ```
 


### PR DESCRIPTION
## Summary

Checked directly with Mintlify team, who confirmed that `mint` is the new package and `mintlify` is deprecated.

- Updates all CLI references from the deprecated `mintlify` npm package to the official `mint` package in README.md and CLAUDE.md
- Updates install commands, dev/broken-links commands, and troubleshooting instructions

## Test plan

- [ ] Verify `npm i -g mint` installs successfully
- [ ] Verify `mint dev` runs the local preview server
- [ ] Verify `mint broken-links` works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)