### PR TITLE
Enable API playground for glossary language pairs endpoint

### DIFF
--- a/api-reference/multilingual-glossaries/list-language-pairs-supported-by-glossaries.mdx
+++ b/api-reference/multilingual-glossaries/list-language-pairs-supported-by-glossaries.mdx
@@ -1,7 +1,6 @@
 ---
 openapi: "get /v2/glossary-language-pairs"
 title: "List language pairs supported for glossaries"
-playground: none
 ---
 
 <Info>This endpoint returns all possible language pairs for glossaries.


### PR DESCRIPTION
## Summary
- Remove `playground: none` from the glossary language pairs endpoint page so the "Try It" button is available for developers to test the API directly from the docs

## Test plan
- [ ] Verify the "Try It" button appears on `/api-reference/multilingual-glossaries/list-language-pairs-supported-by-glossaries`
- [ ] Confirm the playground sends a valid request and returns a response

🤖 Generated with [Claude Code](https://claude.com/claude-code)