### PR TITLE
Revert: disable playground for glossary language pairs endpoint

### DIFF
--- a/api-reference/multilingual-glossaries/list-language-pairs-supported-by-glossaries.mdx
+++ b/api-reference/multilingual-glossaries/list-language-pairs-supported-by-glossaries.mdx
@@ -1,6 +1,7 @@
 ---
 openapi: "get /v2/glossary-language-pairs"
 title: "List language pairs supported for glossaries"
+playground: none
 ---
 
 <Info>This endpoint returns all possible language pairs for glossaries.


### PR DESCRIPTION
## Summary
- Re-add `playground: none` to the glossary language pairs endpoint page
- Glossary endpoints don't support CORS, causing the playground to fail with errors
- All other glossary endpoints already have the playground disabled

Reverts #329

## Test plan
- [ ] Verify the "Try It" button no longer appears on `/api-reference/multilingual-glossaries/list-language-pairs-supported-by-glossaries`

🤖 Generated with [Claude Code](https://claude.com/claude-code)