### PR TITLE
docs: extend style rules for consistency

### DIFF
--- a/api-reference/style-rules.mdx
+++ b/api-reference/style-rules.mdx
@@ -12,6 +12,24 @@ description: "Manage a shared list of rules for style, formatting, and more"
 
 The style rules feature allows you to select a set of rules to apply when translating text. These rules make changes to your text according to the selected formatting and spelling conventions.
 
+### Inclusive Language and Technical Consistency
+
+To ensure clarity, professionalism, and inclusivity in your translations, follow these guidelines:
+
+**Inclusive Language:**
+- Use gender-neutral language where possible.
+- Avoid assumptions about gender, race, or other personal characteristics.
+- Use inclusive terms for groups of people (e.g., "users" instead of "guys").
+- Be mindful of cultural sensitivities and avoid stereotypes.
+
+**Technical Consistency:**
+- Use consistent terminology for technical concepts (e.g., always use "API endpoint" instead of "URL").
+- Follow established naming conventions for technical terms.
+- Ensure consistency in formatting (e.g., date formats, number formats).
+- Use the same terminology across all documentation and translations.
+
+##
+
 You can create style rules in the UI at [https://deepl.com/custom-rules](https://deepl.com/custom-rules).
 
 Both glossaries and style rules are unique to each of DeepL's global data centers and are not shared between them. Clients using the `api-us.deepl.com` endpoint will not be able to access glossaries or style rules created in the UI at this time.


### PR DESCRIPTION
Added sections on Inclusive Language and Technical Consistency to the style guide.