### PR TITLE
Bump actions/checkout to v5 in sync workflow

### DIFF
--- a/.github/workflows/sync-openapi-specs.yml
+++ b/.github/workflows/sync-openapi-specs.yml
@@ -16,12 +16,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout api-docs
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: api-docs
 
       - name: Checkout openapi repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: DeepLcom/openapi
           token: ${{ secrets.OPENAPI_SYNC_TOKEN }}


### PR DESCRIPTION
## Summary
- Bumps `actions/checkout` from v4 to v5 to resolve the Node.js 20 deprecation warning

## Test plan
- [ ] Re-run sync workflow and verify no deprecation warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)