### PR TITLE
Add style rules use cases

### DIFF
--- a/api-reference/style-rules.mdx
+++ b/api-reference/style-rules.mdx
@@ -22,6 +22,16 @@ A **style rule list** contains two types of rules:
 
 Both configured rules and custom instructions are applied during translation to ensure your translations match your style requirements. They work together to provide comprehensive style control over your translated content.
 
+### Example use cases
+
+Style rules are useful when translated content must follow the same writing conventions across products, teams, or regions. For example, you can use a style rule list to:
+
+- Keep product documentation consistent by enforcing date, time, number, and punctuation conventions across translated release notes, help-center articles, and API guides
+- Apply a brand voice to customer-facing content, such as using a friendly tone for support replies while keeping legal or billing text neutral and precise
+- Standardize locale-specific formatting for ecommerce catalogs, including measurements, currency formatting, and capitalization in product titles
+- Adapt internal communication for regional teams, such as preferring formal address in HR policies or concise imperative language in operational runbooks
+- Combine predefined formatting rules with custom instructions, such as "avoid idioms", "keep UI labels short", or "preserve product names exactly as written"
+
 ### Limits
 
 - There is no limit to how many predefined rules can be selected per style rule list


### PR DESCRIPTION
## Summary\n- Add concrete examples of when developers can use style rule lists\n- Cover documentation, support, ecommerce, internal communications, and custom instruction scenarios\n\n## Validation\n- git diff --check -- api-reference/style-rules.mdx\n- Checked against CLAUDE.md style guidance for concise docs copy, no em dashes, and no placeholder comments\n\nCloses #197