### PR TITLE
docs(write): add /v2/write/correct corrections-only endpoint

### DIFF
--- a/api-reference/improve-text.mdx
+++ b/api-reference/improve-text.mdx
@@ -14,10 +14,15 @@ sidebarTitle: "Overview"
 </Info>
 ### DeepL API for Write overview
 
-DeepL API for Write is accessible through an HTTP interface and currently consists of a single endpoint for text improvement, `/write/rephrase`, which is described below. The endpoint:
+DeepL API for Write is accessible through an HTTP interface and consists of two endpoints:
 
-* Accepts both form-encoded (`Content-Type: application/x-www-form-urlencoded`) and JSON-encoded (`Content-Type: application/json`) request bodies
-* Returns JSON-encoded responses
+* [`/write/rephrase`](/api-reference/improve-text/request-text-improvement) — broad text improvement. Fixes spelling and grammar and may also rewrite sentences for clarity, style, or tone.
+* [`/write/correct`](/api-reference/improve-text/correct-text) — corrections-only mode. Fixes spelling and grammar errors with minimal changes to wording. Use this when you want the model to leave the author's voice intact.
+
+Both endpoints:
+
+* Accept both form-encoded (`Content-Type: application/x-www-form-urlencoded`) and JSON-encoded (`Content-Type: application/json`) request bodies
+* Return JSON-encoded responses
 
 The client libraries support all features of the text improvement endpoint. The text improvement feature is currently only available to DeepL API Pro customers and is not yet available in DeepL API Free.
 
@@ -179,6 +184,6 @@ We've added a new column to the [API key-level usage report](/docs/getting-start
 
 #### Is "Corrections Only" mode available in the API?
 
-No. "Corrections Only" is a mode that fixes spelling and grammatical errors only without broader rephrasing. It is currently only available in the DeepL Translator UI. 
+Yes. Send your request to [`/write/correct`](/api-reference/improve-text/correct-text). This endpoint fixes spelling and grammar errors with minimal changes to wording, matching the "Corrections Only" mode in the DeepL Translator UI.
 
-If you make an API request to `/write/rephrase` and omit both `writing_style` and `tone`, the API uses its default improvement mode. This corrects grammar and spelling but may also make broader changes than the "Corrections Only" mode in the UI.
+If you instead send a request to `/write/rephrase` and omit both `writing_style` and `tone`, the API uses its default improvement mode. This corrects grammar and spelling but may also make broader changes than `/write/correct`.

--- a/api-reference/improve-text/correct-text.mdx
+++ b/api-reference/improve-text/correct-text.mdx
@@ -1,0 +1,3 @@
+---
+openapi: post /v2/write/correct
+---

--- a/api-reference/improve-text/correct-text.mdx
+++ b/api-reference/improve-text/correct-text.mdx
@@ -1,3 +1,9 @@
 ---
 openapi: post /v2/write/correct
+title: "Correct text"
+description: "Learn how to fix spelling and grammar errors without rewriting text for style or tone."
 ---
+
+Send one or more texts to `/v2/write/correct` to fix spelling and grammar with minimal changes to wording. This matches the "Corrections Only" mode in the DeepL Translator UI. Unlike [`/v2/write/rephrase`](/api-reference/improve-text/request-text-improvement), this endpoint does not accept `writing_style` or `tone` and does not rewrite sentences for clarity.
+
+See the [Improve text overview](/api-reference/improve-text) for the list of supported target languages and request-size limits.

--- a/api-reference/improve-text/correct-text.mdx
+++ b/api-reference/improve-text/correct-text.mdx
@@ -1,9 +1,7 @@
 ---
 openapi: post /v2/write/correct
 title: "Correct text"
-description: "Learn how to fix spelling and grammar errors without rewriting text for style or tone."
+description: "Fixes spelling and grammar errors with minimal changes to wording."
 ---
 
-Send one or more texts to `/v2/write/correct` to fix spelling and grammar with minimal changes to wording. This matches the "Corrections Only" mode in the DeepL Translator UI. Unlike [`/v2/write/rephrase`](/api-reference/improve-text/request-text-improvement), this endpoint does not accept `writing_style` or `tone` and does not rewrite sentences for clarity.
-
-See the [Improve text overview](/api-reference/improve-text) for the list of supported target languages and request-size limits.
+The `/v2/write/correct` endpoint fixes spelling and grammar errors in one or more texts with minimal changes to wording, matching the "Corrections Only" mode in the DeepL Translator UI. It does not accept `writing_style` or `tone` and does not rephrase sentences for clarity. The broader [`/v2/write/rephrase`](/api-reference/improve-text/request-text-improvement) endpoint supports those parameters.

--- a/api-reference/improve-text/request-text-improvement.mdx
+++ b/api-reference/improve-text/request-text-improvement.mdx
@@ -1,3 +1,9 @@
 ---
 openapi: post /v2/write/rephrase
+title: "Improve text"
+description: "Learn how to improve text by correcting spelling and grammar or rewriting for a target writing style or tone."
 ---
+
+Send one or more texts to `/v2/write/rephrase` to get them rewritten for clarity, style, or tone. The endpoint corrects spelling and grammar and may rephrase sentences to match the requested `writing_style` or `tone`. If you only want to fix mistakes without changing wording, use [`/v2/write/correct`](/api-reference/improve-text/correct-text) instead.
+
+See the [Improve text overview](/api-reference/improve-text) for the list of supported target languages, supported styles and tones, and request-size limits.

--- a/api-reference/improve-text/request-text-improvement.mdx
+++ b/api-reference/improve-text/request-text-improvement.mdx
@@ -1,9 +1,7 @@
 ---
 openapi: post /v2/write/rephrase
 title: "Improve text"
-description: "Learn how to improve text by correcting spelling and grammar or rewriting for a target writing style or tone."
+description: "Improves text by correcting spelling and grammar and rewriting for a target writing style or tone."
 ---
 
-Send one or more texts to `/v2/write/rephrase` to get them rewritten for clarity, style, or tone. The endpoint corrects spelling and grammar and may rephrase sentences to match the requested `writing_style` or `tone`. If you only want to fix mistakes without changing wording, use [`/v2/write/correct`](/api-reference/improve-text/correct-text) instead.
-
-See the [Improve text overview](/api-reference/improve-text) for the list of supported target languages, supported styles and tones, and request-size limits.
+The `/v2/write/rephrase` endpoint improves one or more texts by correcting spelling and grammar and rephrasing sentences for clarity. With the optional `writing_style` or `tone` parameters, the rewrite targets a specific style or tone. Its corrections-only counterpart, [`/v2/write/correct`](/api-reference/improve-text/correct-text), is limited to fixing mistakes with minimal changes to wording.

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -2413,7 +2413,7 @@
         "tags": [
           "RephraseText"
         ],
-        "summary": "Request text improvement",
+        "summary": "Improve text",
         "operationId": "rephraseText",
         "requestBody": {
           "required": true,

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -42,6 +42,10 @@
       "description": "The `rephrase` endpoint  is used to make corrections and adjustments to texts based on style or tone."
     },
     {
+      "name": "CorrectText",
+      "description": "The `correct` endpoint fixes spelling and grammar errors without broader rephrasing. Use it when you want\na minimal-change correction pass rather than the broader rewriting performed by `rephrase`."
+    },
+    {
       "name": "ManageMultilingualGlossaries",
       "description": "The *glossary* functions allow you to create, inspect, edit and delete glossaries.\nGlossaries created with the glossary function can be used in translate requests by specifying the\n`glossary_id` parameter. A glossary contains (several) dictionaries.\nA dictionary is a mapping of source phrases to target phrases for a single language pair.\nIf you encounter issues, please let us know at support@DeepL.com.\n\nCurrently you can create glossaries with any of the languages DeepL supports (with the exception of Thai).\n\nThe maximum size limit for a glossary is 10 MiB = 10485760 bytes and each source/target text,\nas well as the name of the glossary, is limited to 1024 UTF-8 bytes.\nA total of 1000 glossaries are allowed per account.\n\nWhen creating a dictionary with target language `EN`, `PT`, or `ZH`, it's not necessary to specify a variant\n(e.g. `EN-US`, `EN-GB`, `PT-PT`, `PT-BR`, or `ZH-HANS`).\nDictionaries with target language `EN` can be used in translations with either English variant.\nSimilarly `PT`, and `ZH` dictionaries can be used in translations with their corresponding variants.\n(When you provide the ID of a glossary to a translation, the appropriate dictionary is automatically applied. Currently glossaries can not yet be used with source language detection.)\n\nGlossaries created via the DeepL API are now unified with glossaries created via the DeepL website and DeepL apps.\nPlease only use the v3 glossary API in conjunction with multilingual or edited glossaries from the website."
     },
@@ -2506,6 +2510,135 @@
                 }
               }
             }
+          }
+        },
+        "security": [
+          {
+            "auth_header": []
+          }
+        ]
+      }
+    },
+    "/v2/write/correct": {
+      "post": {
+        "tags": [
+          "CorrectText"
+        ],
+        "summary": "Correct text",
+        "description": "Fix spelling and grammar errors in one or more texts. Unlike `/v2/write/rephrase`, this endpoint applies\na minimal-change correction pass and does not rewrite the text for style or tone.",
+        "operationId": "correctText",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "text"
+                ],
+                "properties": {
+                  "text": {
+                    "description": "Text to be corrected. Only UTF-8-encoded plain text is supported. Corrections are returned in the same order as they are requested.",
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "example": "this is a example sentence to imprve"
+                    }
+                  },
+                  "target_lang": {
+                    "$ref": "#/components/schemas/TargetLanguageWrite"
+                  }
+                }
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "text"
+                ],
+                "properties": {
+                  "text": {
+                    "description": "Text to be corrected. Only UTF-8-encoded plain text is supported. Corrections are returned in the same order as they are requested.",
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "example": "this is a example sentence to imprve"
+                    }
+                  },
+                  "target_lang": {
+                    "$ref": "#/components/schemas/TargetLanguageWrite"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful text correction.",
+            "headers": {
+              "X-Trace-ID": {
+                "$ref": "#/components/headers/X-Trace-ID"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "improvements": {
+                      "type": "array",
+                      "minItems": 1,
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "detected_source_language": {
+                            "description": "The language detected in the source text.",
+                            "type": "string",
+                            "example": "en"
+                          },
+                          "target_language": {
+                            "description": "The target language specified by the request.",
+                            "type": "string",
+                            "example": "en-US"
+                          },
+                          "text": {
+                            "description": "The corrected text.",
+                            "type": "string",
+                            "example": "This is a sample sentence to improve."
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "413": {
+            "$ref": "#/components/responses/PayloadTooLarge"
+          },
+          "415": {
+            "description": "Unsupported Content-Type. Use `application/json` or `application/x-www-form-urlencoded`."
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          },
+          "456": {
+            "$ref": "#/components/responses/QuotaExceeded"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          },
+          "504": {
+            "$ref": "#/components/responses/ServiceUnavailable"
           }
         },
         "security": [

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -2498,6 +2498,11 @@
                             "type": "string",
                             "example": "en"
                           },
+                          "target_language": {
+                            "description": "The target language specified by the request.",
+                            "type": "string",
+                            "example": "en-US"
+                          },
                           "text": {
                             "description": "The improved text.",
                             "type": "string",

--- a/api-reference/openapi.yaml
+++ b/api-reference/openapi.yaml
@@ -39,6 +39,10 @@ tags:
 - name: RephraseText
   description: |-
     The `rephrase` endpoint  is used to make corrections and adjustments to texts based on style or tone.
+- name: CorrectText
+  description: |-
+    The `correct` endpoint fixes spelling and grammar errors without broader rephrasing. Use it when you want
+    a minimal-change correction pass rather than the broader rewriting performed by `rephrase`.
 - name: ManageMultilingualGlossaries
   description: |-
     The *glossary* functions allow you to create, inspect, edit and delete glossaries.
@@ -1754,6 +1758,95 @@ paths:
                           description: The improved text.
                           type: string
                           example: This is a sample sentence to improve.
+      security:
+        - auth_header: [ ]
+  /v2/write/correct:
+    post:
+      tags:
+        - CorrectText
+      summary: Correct text
+      description: |-
+        Fix spelling and grammar errors in one or more texts. Unlike `/v2/write/rephrase`, this endpoint applies
+        a minimal-change correction pass and does not rewrite the text for style or tone.
+      operationId: correctText
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - text
+              properties:
+                text:
+                  description: Text to be corrected. Only UTF-8-encoded plain text is supported. Corrections are
+                    returned in the same order as they are requested.
+                  type: array
+                  items:
+                    type: string
+                    example: this is a example sentence to imprve
+                target_lang:
+                  $ref: '#/components/schemas/TargetLanguageWrite'
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              required:
+                - text
+              properties:
+                text:
+                  description: Text to be corrected. Only UTF-8-encoded plain text is supported. Corrections are
+                    returned in the same order as they are requested.
+                  type: array
+                  items:
+                    type: string
+                    example: this is a example sentence to imprve
+                target_lang:
+                  $ref: '#/components/schemas/TargetLanguageWrite'
+      responses:
+        200:
+          description: Successful text correction.
+          headers:
+            X-Trace-ID:
+              $ref: '#/components/headers/X-Trace-ID'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  improvements:
+                    type: array
+                    minItems: 1
+                    items:
+                      type: object
+                      properties:
+                        detected_source_language:
+                          description: The language detected in the source text.
+                          type: string
+                          example: en
+                        target_language:
+                          description: The target language specified by the request.
+                          type: string
+                          example: en-US
+                        text:
+                          description: The corrected text.
+                          type: string
+                          example: This is a sample sentence to improve.
+        400:
+          $ref: '#/components/responses/BadRequest'
+        403:
+          $ref: '#/components/responses/Forbidden'
+        413:
+          $ref: '#/components/responses/PayloadTooLarge'
+        415:
+          description: Unsupported Content-Type. Use `application/json` or `application/x-www-form-urlencoded`.
+        429:
+          $ref: '#/components/responses/TooManyRequests'
+        456:
+          $ref: '#/components/responses/QuotaExceeded'
+        500:
+          $ref: '#/components/responses/InternalServerError'
+        504:
+          $ref: '#/components/responses/ServiceUnavailable'
       security:
         - auth_header: [ ]
   /v2/usage:

--- a/api-reference/openapi.yaml
+++ b/api-reference/openapi.yaml
@@ -1754,6 +1754,10 @@ paths:
                           description: The language detected in the source text.
                           type: string
                           example: en
+                        target_language:
+                          description: The target language specified by the request.
+                          type: string
+                          example: en-US
                         text:
                           description: The improved text.
                           type: string

--- a/api-reference/openapi.yaml
+++ b/api-reference/openapi.yaml
@@ -1690,7 +1690,7 @@ paths:
     post:
       tags:
         - RephraseText
-      summary: Request text improvement
+      summary: Improve text
       operationId: rephraseText
       requestBody:
         required: true

--- a/docs.json
+++ b/docs.json
@@ -251,7 +251,8 @@
             "group": "Write",
             "pages": [
               "api-reference/improve-text",
-              "api-reference/improve-text/request-text-improvement"
+              "api-reference/improve-text/request-text-improvement",
+              "api-reference/improve-text/correct-text"
             ]
           },
           {


### PR DESCRIPTION
## Summary

Documents the new corrections-only mode on the Write API.

- Adds `/v2/write/correct` path and a `CorrectText` tag to `api-reference/openapi.yaml`.
- Adds `api-reference/improve-text/correct-text.mdx`, driven by the OpenAPI spec.
- Updates the `Improve text` overview (`api-reference/improve-text.mdx`):
  - Describes both `/write/rephrase` and `/write/correct` and links to each.
  - Fixes the FAQ entry that previously said Corrections Only mode was UI-only.
- Registers the new page in `docs.json`.

## Behavior summary

`/v2/write/correct` performs a minimal-change correction pass on one or more texts. Unlike `/v2/write/rephrase`, it does not accept `writing_style` or `tone` and does not rewrite for style.

Request body (JSON or form-urlencoded):

| Field | Type | Required | Description |
|---|---|---|---|
| `text` | `array[string]` | yes | Texts to correct |
| `target_lang` | `string` | no | Target language (uses the same `TargetLanguageWrite` set as `/write/rephrase`) |

Response: same `improvements` array shape as `/write/rephrase`, with `text`, `target_language`, and `detected_source_language`.

## Validation (local PublicApi → dev upstreams)

| Case | Status |
|---|---|
| JSON body, `EN-US` | 200 — `"This are wrong sentence..."` → `"These are wrong sentences..."` |
| Form-urlencoded body | 200 |
| Multiple texts | 200 — each item corrected independently |
| German (`DE`) target | 200 — `"Ich gehen heute zum Schule."` → `"Ich gehe heute zur Schule."` |
| Empty `text` array | 400 — `Missing parameter text.` |
| Unsupported `Content-Type` (`text/plain`) | 415 |
| Invalid `target_lang` | 400 — `Value for target_lang not supported.` |

## Test plan

- [ ] `mint dev` renders the new `Improve text > Corrections Only` page without errors
- [ ] `mint broken-links` and `mint broken-links --check-anchors` pass
- [ ] Try-it console on the new endpoint successfully calls the API and returns an `improvements` array
- [ ] Overview page renders the updated FAQ entry and the link to the new page