### PR TITLE
chore(v3-languages): vend API responses as JSON

### DIFF
--- a/.mintignore
+++ b/.mintignore
@@ -1,3 +1,5 @@
 reviews/*
 api-reference/openapi.json
 api-reference/voice/voice.asyncapi.json
+data/*
+scripts/*

--- a/data/v3-languages/README.md
+++ b/data/v3-languages/README.md
@@ -1,0 +1,34 @@
+# Vended `/v3/languages` responses
+
+This directory holds verbatim JSON responses from the DeepL `/v3/languages` endpoints, fetched against `https://api.deepl.com`. Other tooling in this repo (e.g. generated docs and snippets) reads these files instead of calling the API directly.
+
+## Files
+
+| File | Endpoint |
+|---|---|
+| `resources.json` | `GET /v3/languages/resources` |
+| `translate_text.json` | `GET /v3/languages?resource=translate_text&include=beta&include=external` |
+| `translate_document.json` | `GET /v3/languages?resource=translate_document&include=beta&include=external` |
+| `voice.json` | `GET /v3/languages?resource=voice&include=beta&include=external` |
+| `write.json` | `GET /v3/languages?resource=write&include=beta&include=external` |
+| `glossary.json` | `GET /v3/languages?resource=glossary&include=beta&include=external` |
+| `style_rules.json` | `GET /v3/languages?resource=style_rules&include=beta&include=external` |
+
+Each per-resource file requests `include=beta&include=external` so the vended data is the full superset. Consumers filter on the `status` and per-feature `external` fields when they want a narrower view.
+
+## Refreshing
+
+Set `DEEPL_AUTH_KEY` in your environment, then run:
+
+```sh
+python3 scripts/fetch_v3_languages.py
+```
+
+Flags:
+
+- `--free` — hit `https://api-free.deepl.com` instead of the Pro endpoint.
+- `--base-url <url>` — point at any other host (staging, mock, local server). Also configurable via the `DEEPL_API_BASE_URL` environment variable.
+
+The script overwrites every file in this directory.
+
+A scheduled GitHub Action refreshes these files automatically and opens a pull request when the responses change; manual runs are only needed for local testing.

--- a/data/v3-languages/glossary.json
+++ b/data/v3-languages/glossary.json
@@ -1,0 +1,258 @@
+[
+  {
+    "lang": "ar",
+    "name": "Arabic",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "bg",
+    "name": "Bulgarian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "cs",
+    "name": "Czech",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "da",
+    "name": "Danish",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "de",
+    "name": "German",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "el",
+    "name": "Greek",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "en",
+    "name": "English",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "es",
+    "name": "Spanish",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "et",
+    "name": "Estonian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "fi",
+    "name": "Finnish",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "fr",
+    "name": "French",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "he",
+    "name": "Hebrew",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "hu",
+    "name": "Hungarian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "id",
+    "name": "Indonesian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "it",
+    "name": "Italian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "ja",
+    "name": "Japanese",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "ko",
+    "name": "Korean",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "lt",
+    "name": "Lithuanian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "lv",
+    "name": "Latvian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "nb",
+    "name": "Norwegian (bokmål)",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "nl",
+    "name": "Dutch",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "pl",
+    "name": "Polish",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "pt",
+    "name": "Portuguese",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "ro",
+    "name": "Romanian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "ru",
+    "name": "Russian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "sk",
+    "name": "Slovak",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "sl",
+    "name": "Slovenian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "sv",
+    "name": "Swedish",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "tr",
+    "name": "Turkish",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "uk",
+    "name": "Ukrainian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "vi",
+    "name": "Vietnamese",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "zh",
+    "name": "Chinese",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  }
+]

--- a/data/v3-languages/resources.json
+++ b/data/v3-languages/resources.json
@@ -1,0 +1,98 @@
+[
+  {
+    "name": "translate_text",
+    "features": [
+      {
+        "name": "auto_detection",
+        "needs_source_support": true
+      },
+      {
+        "name": "formality",
+        "needs_target_support": true
+      },
+      {
+        "name": "glossary",
+        "needs_source_support": true,
+        "needs_target_support": true
+      },
+      {
+        "name": "style_rules",
+        "needs_target_support": true
+      },
+      {
+        "name": "tag_handling",
+        "needs_source_support": true,
+        "needs_target_support": true
+      }
+    ]
+  },
+  {
+    "name": "translate_document",
+    "features": [
+      {
+        "name": "auto_detection",
+        "needs_source_support": true
+      },
+      {
+        "name": "formality",
+        "needs_target_support": true
+      },
+      {
+        "name": "glossary",
+        "needs_source_support": true,
+        "needs_target_support": true
+      }
+    ]
+  },
+  {
+    "name": "glossary",
+    "features": []
+  },
+  {
+    "name": "style_rules",
+    "features": []
+  },
+  {
+    "name": "voice",
+    "features": [
+      {
+        "name": "auto_detection",
+        "needs_source_support": true
+      },
+      {
+        "name": "formality",
+        "needs_target_support": true
+      },
+      {
+        "name": "glossary",
+        "needs_source_support": true,
+        "needs_target_support": true
+      },
+      {
+        "name": "transcription",
+        "needs_source_support": true
+      },
+      {
+        "name": "translated_speech",
+        "needs_target_support": true
+      }
+    ]
+  },
+  {
+    "name": "write",
+    "features": [
+      {
+        "name": "auto_detection",
+        "needs_source_support": true
+      },
+      {
+        "name": "tone",
+        "needs_target_support": true
+      },
+      {
+        "name": "writing_style",
+        "needs_target_support": true
+      }
+    ]
+  }
+]

--- a/data/v3-languages/style_rules.json
+++ b/data/v3-languages/style_rules.json
@@ -1,0 +1,66 @@
+[
+  {
+    "lang": "de",
+    "name": "German",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "en",
+    "name": "English",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "es",
+    "name": "Spanish",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "fr",
+    "name": "French",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "it",
+    "name": "Italian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "ja",
+    "name": "Japanese",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "ko",
+    "name": "Korean",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "zh",
+    "name": "Chinese",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  }
+]

--- a/data/v3-languages/translate_document.json
+++ b/data/v3-languages/translate_document.json
@@ -1,0 +1,1250 @@
+[
+  {
+    "lang": "ace",
+    "name": "Acehnese",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "af",
+    "name": "Afrikaans",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "an",
+    "name": "Aragonese",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "ar",
+    "name": "Arabic",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "as",
+    "name": "Assamese",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "ay",
+    "name": "Aymara",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "az",
+    "name": "Azerbaijani",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "ba",
+    "name": "Bashkir",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "be",
+    "name": "Belarusian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "bg",
+    "name": "Bulgarian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "bho",
+    "name": "Bhojpuri",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "bn",
+    "name": "Bengali",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "br",
+    "name": "Breton",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "bs",
+    "name": "Bosnian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "ca",
+    "name": "Catalan",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "ceb",
+    "name": "Cebuano",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "ckb",
+    "name": "Kurdish (Sorani)",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "cs",
+    "name": "Czech",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "cy",
+    "name": "Welsh",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "da",
+    "name": "Danish",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "de",
+    "name": "German",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "formality": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "el",
+    "name": "Greek",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "en",
+    "name": "English",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "en-GB",
+    "name": "English (British)",
+    "status": "stable",
+    "usable_as_source": false,
+    "usable_as_target": true,
+    "features": {
+      "glossary": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "en-US",
+    "name": "English (American)",
+    "status": "stable",
+    "usable_as_source": false,
+    "usable_as_target": true,
+    "features": {
+      "glossary": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "eo",
+    "name": "Esperanto",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "es",
+    "name": "Spanish",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "formality": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "es-419",
+    "name": "Spanish (Latin American)",
+    "status": "stable",
+    "usable_as_source": false,
+    "usable_as_target": true,
+    "features": {
+      "formality": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "et",
+    "name": "Estonian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "eu",
+    "name": "Basque",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "fa",
+    "name": "Persian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "fi",
+    "name": "Finnish",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "fr",
+    "name": "French",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "formality": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "ga",
+    "name": "Irish",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "gl",
+    "name": "Galician",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "gn",
+    "name": "Guarani",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "gom",
+    "name": "Konkani",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "gu",
+    "name": "Gujarati",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "ha",
+    "name": "Hausa",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "he",
+    "name": "Hebrew",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "hi",
+    "name": "Hindi",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "hr",
+    "name": "Croatian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "ht",
+    "name": "Haitian Creole",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "hu",
+    "name": "Hungarian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "hy",
+    "name": "Armenian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "id",
+    "name": "Indonesian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "ig",
+    "name": "Igbo",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "is",
+    "name": "Icelandic",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "it",
+    "name": "Italian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "formality": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "ja",
+    "name": "Japanese",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "formality": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "jv",
+    "name": "Javanese",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "ka",
+    "name": "Georgian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "kk",
+    "name": "Kazakh",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "kmr",
+    "name": "Kurdish (Kurmanji)",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "ko",
+    "name": "Korean",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "ky",
+    "name": "Kyrgyz",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "la",
+    "name": "Latin",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "lb",
+    "name": "Luxembourgish",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "lmo",
+    "name": "Lombard",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "ln",
+    "name": "Lingala",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "lt",
+    "name": "Lithuanian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "lv",
+    "name": "Latvian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "mai",
+    "name": "Maithili",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "mg",
+    "name": "Malagasy",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "mi",
+    "name": "Maori",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "mk",
+    "name": "Macedonian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "ml",
+    "name": "Malayalam",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "mn",
+    "name": "Mongolian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "mr",
+    "name": "Marathi",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "ms",
+    "name": "Malay",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "mt",
+    "name": "Maltese",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "my",
+    "name": "Burmese",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "nb",
+    "name": "Norwegian (bokmål)",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "ne",
+    "name": "Nepali",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "nl",
+    "name": "Dutch",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "formality": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "oc",
+    "name": "Occitan",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "om",
+    "name": "Oromo",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "pa",
+    "name": "Punjabi",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "pag",
+    "name": "Pangasinan",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "pam",
+    "name": "Kapampangan",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "pl",
+    "name": "Polish",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "formality": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "prs",
+    "name": "Dari",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "ps",
+    "name": "Pashto",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "pt",
+    "name": "Portuguese",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "formality": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "pt-BR",
+    "name": "Portuguese (Brazilian)",
+    "status": "stable",
+    "usable_as_source": false,
+    "usable_as_target": true,
+    "features": {
+      "formality": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "pt-PT",
+    "name": "Portuguese (European)",
+    "status": "stable",
+    "usable_as_source": false,
+    "usable_as_target": true,
+    "features": {
+      "formality": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "qu",
+    "name": "Quechua",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "ro",
+    "name": "Romanian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "ru",
+    "name": "Russian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "formality": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "sa",
+    "name": "Sanskrit",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "scn",
+    "name": "Sicilian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "sk",
+    "name": "Slovak",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "sl",
+    "name": "Slovenian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "sq",
+    "name": "Albanian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "sr",
+    "name": "Serbian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "st",
+    "name": "Sesotho",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "su",
+    "name": "Sundanese",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "sv",
+    "name": "Swedish",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "sw",
+    "name": "Swahili",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "ta",
+    "name": "Tamil",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "te",
+    "name": "Telugu",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "tg",
+    "name": "Tajik",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "th",
+    "name": "Thai",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "tk",
+    "name": "Turkmen",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "tl",
+    "name": "Tagalog",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "tn",
+    "name": "Tswana",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "tr",
+    "name": "Turkish",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "tt",
+    "name": "Tatar",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "uk",
+    "name": "Ukrainian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "ur",
+    "name": "Urdu",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "uz",
+    "name": "Uzbek",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "vi",
+    "name": "Vietnamese",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "wo",
+    "name": "Wolof",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "xh",
+    "name": "Xhosa",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "yi",
+    "name": "Yiddish",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "yue",
+    "name": "Cantonese",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "zh",
+    "name": "Chinese",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "zh-Hans",
+    "name": "Chinese (simplified)",
+    "status": "stable",
+    "usable_as_source": false,
+    "usable_as_target": true,
+    "features": {
+      "glossary": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "zh-Hant",
+    "name": "Chinese (traditional)",
+    "status": "stable",
+    "usable_as_source": false,
+    "usable_as_target": true,
+    "features": {
+      "glossary": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "zu",
+    "name": "Zulu",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {}
+  }
+]

--- a/data/v3-languages/translate_text.json
+++ b/data/v3-languages/translate_text.json
@@ -1,0 +1,2069 @@
+[
+  {
+    "lang": "ace",
+    "name": "Acehnese",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "af",
+    "name": "Afrikaans",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "an",
+    "name": "Aragonese",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "ar",
+    "name": "Arabic",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "as",
+    "name": "Assamese",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "ay",
+    "name": "Aymara",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "az",
+    "name": "Azerbaijani",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "ba",
+    "name": "Bashkir",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "be",
+    "name": "Belarusian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "bg",
+    "name": "Bulgarian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "bho",
+    "name": "Bhojpuri",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "bn",
+    "name": "Bengali",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "br",
+    "name": "Breton",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "bs",
+    "name": "Bosnian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "ca",
+    "name": "Catalan",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "ceb",
+    "name": "Cebuano",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "ckb",
+    "name": "Kurdish (Sorani)",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "cs",
+    "name": "Czech",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "cy",
+    "name": "Welsh",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "da",
+    "name": "Danish",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "de",
+    "name": "German",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "formality": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      },
+      "style_rules": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "de-CH",
+    "name": "German (Swiss)",
+    "status": "beta",
+    "usable_as_source": false,
+    "usable_as_target": true,
+    "features": {
+      "formality": {
+        "status": "beta"
+      },
+      "glossary": {
+        "status": "beta"
+      },
+      "tag_handling": {
+        "status": "beta"
+      }
+    }
+  },
+  {
+    "lang": "de-DE",
+    "name": "German",
+    "status": "stable",
+    "usable_as_source": false,
+    "usable_as_target": true,
+    "features": {
+      "formality": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      },
+      "style_rules": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "el",
+    "name": "Greek",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "en",
+    "name": "English",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      },
+      "style_rules": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "en-GB",
+    "name": "English (British)",
+    "status": "stable",
+    "usable_as_source": false,
+    "usable_as_target": true,
+    "features": {
+      "glossary": {
+        "status": "stable"
+      },
+      "style_rules": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "en-US",
+    "name": "English (American)",
+    "status": "stable",
+    "usable_as_source": false,
+    "usable_as_target": true,
+    "features": {
+      "glossary": {
+        "status": "stable"
+      },
+      "style_rules": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "eo",
+    "name": "Esperanto",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "es",
+    "name": "Spanish",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "formality": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      },
+      "style_rules": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "es-419",
+    "name": "Spanish (Latin American)",
+    "status": "stable",
+    "usable_as_source": false,
+    "usable_as_target": true,
+    "features": {
+      "formality": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      },
+      "style_rules": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "et",
+    "name": "Estonian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "eu",
+    "name": "Basque",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "fa",
+    "name": "Persian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "fi",
+    "name": "Finnish",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "fr",
+    "name": "French",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "formality": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      },
+      "style_rules": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "fr-CA",
+    "name": "French (Canadian)",
+    "status": "beta",
+    "usable_as_source": false,
+    "usable_as_target": true,
+    "features": {
+      "formality": {
+        "status": "beta"
+      },
+      "glossary": {
+        "status": "beta"
+      },
+      "style_rules": {
+        "status": "beta"
+      },
+      "tag_handling": {
+        "status": "beta"
+      }
+    }
+  },
+  {
+    "lang": "fr-FR",
+    "name": "French",
+    "status": "stable",
+    "usable_as_source": false,
+    "usable_as_target": true,
+    "features": {
+      "formality": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      },
+      "style_rules": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "ga",
+    "name": "Irish",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "gl",
+    "name": "Galician",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "gn",
+    "name": "Guarani",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "gom",
+    "name": "Konkani",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "gu",
+    "name": "Gujarati",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "ha",
+    "name": "Hausa",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "he",
+    "name": "Hebrew",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "hi",
+    "name": "Hindi",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "hr",
+    "name": "Croatian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "ht",
+    "name": "Haitian Creole",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "hu",
+    "name": "Hungarian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "hy",
+    "name": "Armenian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "id",
+    "name": "Indonesian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "ig",
+    "name": "Igbo",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "is",
+    "name": "Icelandic",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "it",
+    "name": "Italian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "formality": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      },
+      "style_rules": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "ja",
+    "name": "Japanese",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "formality": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      },
+      "style_rules": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "jv",
+    "name": "Javanese",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "ka",
+    "name": "Georgian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "kk",
+    "name": "Kazakh",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "kmr",
+    "name": "Kurdish (Kurmanji)",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "ko",
+    "name": "Korean",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      },
+      "style_rules": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "ky",
+    "name": "Kyrgyz",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "la",
+    "name": "Latin",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "lb",
+    "name": "Luxembourgish",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "lmo",
+    "name": "Lombard",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "ln",
+    "name": "Lingala",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "lt",
+    "name": "Lithuanian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "lv",
+    "name": "Latvian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "mai",
+    "name": "Maithili",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "mg",
+    "name": "Malagasy",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "mi",
+    "name": "Maori",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "mk",
+    "name": "Macedonian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "ml",
+    "name": "Malayalam",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "mn",
+    "name": "Mongolian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "mr",
+    "name": "Marathi",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "ms",
+    "name": "Malay",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "mt",
+    "name": "Maltese",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "my",
+    "name": "Burmese",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "nb",
+    "name": "Norwegian (bokmål)",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "ne",
+    "name": "Nepali",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "nl",
+    "name": "Dutch",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "formality": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "oc",
+    "name": "Occitan",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "om",
+    "name": "Oromo",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "pa",
+    "name": "Punjabi",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "pag",
+    "name": "Pangasinan",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "pam",
+    "name": "Kapampangan",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "pl",
+    "name": "Polish",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "formality": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "prs",
+    "name": "Dari",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "ps",
+    "name": "Pashto",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "pt",
+    "name": "Portuguese",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "formality": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "pt-BR",
+    "name": "Portuguese (Brazilian)",
+    "status": "stable",
+    "usable_as_source": false,
+    "usable_as_target": true,
+    "features": {
+      "formality": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "pt-PT",
+    "name": "Portuguese (European)",
+    "status": "stable",
+    "usable_as_source": false,
+    "usable_as_target": true,
+    "features": {
+      "formality": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "qu",
+    "name": "Quechua",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "ro",
+    "name": "Romanian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "ru",
+    "name": "Russian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "formality": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "sa",
+    "name": "Sanskrit",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "scn",
+    "name": "Sicilian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "sk",
+    "name": "Slovak",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "sl",
+    "name": "Slovenian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "sq",
+    "name": "Albanian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "sr",
+    "name": "Serbian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "st",
+    "name": "Sesotho",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "su",
+    "name": "Sundanese",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "sv",
+    "name": "Swedish",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "sw",
+    "name": "Swahili",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "ta",
+    "name": "Tamil",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "te",
+    "name": "Telugu",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "tg",
+    "name": "Tajik",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "th",
+    "name": "Thai",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "tk",
+    "name": "Turkmen",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "tl",
+    "name": "Tagalog",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "tn",
+    "name": "Tswana",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "tr",
+    "name": "Turkish",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "ts",
+    "name": "Tsonga",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "tt",
+    "name": "Tatar",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "uk",
+    "name": "Ukrainian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "ur",
+    "name": "Urdu",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "uz",
+    "name": "Uzbek",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "vi",
+    "name": "Vietnamese",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "wo",
+    "name": "Wolof",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "xh",
+    "name": "Xhosa",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "yi",
+    "name": "Yiddish",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "yue",
+    "name": "Cantonese",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "zh",
+    "name": "Chinese",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      },
+      "style_rules": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "zh-Hans",
+    "name": "Chinese (simplified)",
+    "status": "stable",
+    "usable_as_source": false,
+    "usable_as_target": true,
+    "features": {
+      "glossary": {
+        "status": "stable"
+      },
+      "style_rules": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "zh-Hant",
+    "name": "Chinese (traditional)",
+    "status": "stable",
+    "usable_as_source": false,
+    "usable_as_target": true,
+    "features": {
+      "glossary": {
+        "status": "stable"
+      },
+      "style_rules": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "zu",
+    "name": "Zulu",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tag_handling": {
+        "status": "stable"
+      }
+    }
+  }
+]

--- a/data/v3-languages/voice.json
+++ b/data/v3-languages/voice.json
@@ -1,0 +1,845 @@
+[
+  {
+    "lang": "ar",
+    "name": "Arabic",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "glossary": {
+        "status": "stable"
+      },
+      "transcription": {
+        "status": "stable",
+        "external": true
+      },
+      "translated_speech": {
+        "status": "stable",
+        "external": true
+      }
+    }
+  },
+  {
+    "lang": "bg",
+    "name": "Bulgarian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "glossary": {
+        "status": "stable"
+      },
+      "transcription": {
+        "status": "stable",
+        "external": true
+      },
+      "translated_speech": {
+        "status": "stable",
+        "external": true
+      }
+    }
+  },
+  {
+    "lang": "bn",
+    "name": "Bengali",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "transcription": {
+        "status": "stable",
+        "external": true
+      }
+    }
+  },
+  {
+    "lang": "cs",
+    "name": "Czech",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      },
+      "transcription": {
+        "status": "stable"
+      },
+      "translated_speech": {
+        "status": "stable",
+        "external": true
+      }
+    }
+  },
+  {
+    "lang": "da",
+    "name": "Danish",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "glossary": {
+        "status": "stable"
+      },
+      "transcription": {
+        "status": "stable",
+        "external": true
+      },
+      "translated_speech": {
+        "status": "stable",
+        "external": true
+      }
+    }
+  },
+  {
+    "lang": "de",
+    "name": "German",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "formality": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      },
+      "transcription": {
+        "status": "stable"
+      },
+      "translated_speech": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "el",
+    "name": "Greek",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "glossary": {
+        "status": "stable"
+      },
+      "transcription": {
+        "status": "stable",
+        "external": true
+      },
+      "translated_speech": {
+        "status": "stable",
+        "external": true
+      }
+    }
+  },
+  {
+    "lang": "en",
+    "name": "English",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      },
+      "transcription": {
+        "status": "stable"
+      },
+      "translated_speech": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "en-GB",
+    "name": "English (British)",
+    "status": "stable",
+    "usable_as_source": false,
+    "usable_as_target": true,
+    "features": {
+      "glossary": {
+        "status": "stable"
+      },
+      "translated_speech": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "en-US",
+    "name": "English (American)",
+    "status": "stable",
+    "usable_as_source": false,
+    "usable_as_target": true,
+    "features": {
+      "glossary": {
+        "status": "stable"
+      },
+      "translated_speech": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "es",
+    "name": "Spanish",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "formality": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      },
+      "transcription": {
+        "status": "stable"
+      },
+      "translated_speech": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "et",
+    "name": "Estonian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "glossary": {
+        "status": "stable"
+      },
+      "transcription": {
+        "status": "stable",
+        "external": true
+      }
+    }
+  },
+  {
+    "lang": "fi",
+    "name": "Finnish",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      },
+      "transcription": {
+        "status": "stable",
+        "external": true
+      },
+      "translated_speech": {
+        "status": "stable",
+        "external": true
+      }
+    }
+  },
+  {
+    "lang": "fr",
+    "name": "French",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "formality": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      },
+      "transcription": {
+        "status": "stable"
+      },
+      "translated_speech": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "ga",
+    "name": "Irish",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "transcription": {
+        "status": "stable",
+        "external": true
+      }
+    }
+  },
+  {
+    "lang": "he",
+    "name": "Hebrew",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "glossary": {
+        "status": "stable"
+      },
+      "transcription": {
+        "status": "stable",
+        "external": true
+      }
+    }
+  },
+  {
+    "lang": "hr",
+    "name": "Croatian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "transcription": {
+        "status": "stable",
+        "external": true
+      }
+    }
+  },
+  {
+    "lang": "hu",
+    "name": "Hungarian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "glossary": {
+        "status": "stable"
+      },
+      "transcription": {
+        "status": "stable",
+        "external": true
+      },
+      "translated_speech": {
+        "status": "stable",
+        "external": true
+      }
+    }
+  },
+  {
+    "lang": "id",
+    "name": "Indonesian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      },
+      "transcription": {
+        "status": "stable"
+      },
+      "translated_speech": {
+        "status": "stable",
+        "external": true
+      }
+    }
+  },
+  {
+    "lang": "it",
+    "name": "Italian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "formality": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      },
+      "transcription": {
+        "status": "stable"
+      },
+      "translated_speech": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "ja",
+    "name": "Japanese",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "formality": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      },
+      "transcription": {
+        "status": "stable"
+      },
+      "translated_speech": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "ko",
+    "name": "Korean",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      },
+      "transcription": {
+        "status": "stable"
+      },
+      "translated_speech": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "lt",
+    "name": "Lithuanian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "glossary": {
+        "status": "stable"
+      },
+      "transcription": {
+        "status": "stable",
+        "external": true
+      }
+    }
+  },
+  {
+    "lang": "lv",
+    "name": "Latvian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "glossary": {
+        "status": "stable"
+      },
+      "transcription": {
+        "status": "stable",
+        "external": true
+      }
+    }
+  },
+  {
+    "lang": "mt",
+    "name": "Maltese",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "transcription": {
+        "status": "stable",
+        "external": true
+      }
+    }
+  },
+  {
+    "lang": "nb",
+    "name": "Norwegian (bokmål)",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "glossary": {
+        "status": "stable"
+      },
+      "transcription": {
+        "status": "stable",
+        "external": true
+      },
+      "translated_speech": {
+        "status": "stable",
+        "external": true
+      }
+    }
+  },
+  {
+    "lang": "nl",
+    "name": "Dutch",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      },
+      "transcription": {
+        "status": "stable"
+      },
+      "translated_speech": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "pl",
+    "name": "Polish",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "formality": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      },
+      "transcription": {
+        "status": "stable"
+      },
+      "translated_speech": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "pt",
+    "name": "Portuguese",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "formality": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      },
+      "transcription": {
+        "status": "stable"
+      },
+      "translated_speech": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "pt-BR",
+    "name": "Portuguese (Brazilian)",
+    "status": "stable",
+    "usable_as_source": false,
+    "usable_as_target": true,
+    "features": {
+      "formality": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      },
+      "translated_speech": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "pt-PT",
+    "name": "Portuguese (European)",
+    "status": "stable",
+    "usable_as_source": false,
+    "usable_as_target": true,
+    "features": {
+      "formality": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      },
+      "translated_speech": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "ro",
+    "name": "Romanian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      },
+      "transcription": {
+        "status": "stable"
+      },
+      "translated_speech": {
+        "status": "stable",
+        "external": true
+      }
+    }
+  },
+  {
+    "lang": "ru",
+    "name": "Russian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "formality": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      },
+      "transcription": {
+        "status": "stable"
+      },
+      "translated_speech": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "sk",
+    "name": "Slovak",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "glossary": {
+        "status": "stable"
+      },
+      "transcription": {
+        "status": "stable",
+        "external": true
+      },
+      "translated_speech": {
+        "status": "stable",
+        "external": true
+      }
+    }
+  },
+  {
+    "lang": "sl",
+    "name": "Slovenian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "glossary": {
+        "status": "stable"
+      },
+      "transcription": {
+        "status": "stable",
+        "external": true
+      }
+    }
+  },
+  {
+    "lang": "sv",
+    "name": "Swedish",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      },
+      "transcription": {
+        "status": "stable"
+      },
+      "translated_speech": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "th",
+    "name": "Thai",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "transcription": {
+        "status": "stable",
+        "external": true
+      }
+    }
+  },
+  {
+    "lang": "tl",
+    "name": "Tagalog",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "transcription": {
+        "status": "stable",
+        "external": true
+      }
+    }
+  },
+  {
+    "lang": "tr",
+    "name": "Turkish",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      },
+      "transcription": {
+        "status": "stable"
+      },
+      "translated_speech": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "uk",
+    "name": "Ukrainian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      },
+      "transcription": {
+        "status": "stable"
+      },
+      "translated_speech": {
+        "status": "stable",
+        "external": true
+      }
+    }
+  },
+  {
+    "lang": "vi",
+    "name": "Vietnamese",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "glossary": {
+        "status": "stable"
+      },
+      "transcription": {
+        "status": "stable",
+        "external": true
+      },
+      "translated_speech": {
+        "status": "stable",
+        "external": true
+      }
+    }
+  },
+  {
+    "lang": "zh",
+    "name": "Chinese",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "glossary": {
+        "status": "stable"
+      },
+      "transcription": {
+        "status": "stable"
+      },
+      "translated_speech": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "zh-Hans",
+    "name": "Chinese (simplified)",
+    "status": "stable",
+    "usable_as_source": false,
+    "usable_as_target": true,
+    "features": {
+      "glossary": {
+        "status": "stable"
+      },
+      "translated_speech": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "zh-Hant",
+    "name": "Chinese (traditional)",
+    "status": "stable",
+    "usable_as_source": false,
+    "usable_as_target": true,
+    "features": {
+      "glossary": {
+        "status": "stable"
+      },
+      "translated_speech": {
+        "status": "stable"
+      }
+    }
+  }
+]

--- a/data/v3-languages/write.json
+++ b/data/v3-languages/write.json
@@ -1,0 +1,170 @@
+[
+  {
+    "lang": "de",
+    "name": "German",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      },
+      "tone": {
+        "status": "stable"
+      },
+      "writing_style": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "en",
+    "name": "English",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "en-GB",
+    "name": "English (British)",
+    "status": "stable",
+    "usable_as_source": false,
+    "usable_as_target": true,
+    "features": {
+      "tone": {
+        "status": "stable"
+      },
+      "writing_style": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "en-US",
+    "name": "English (American)",
+    "status": "stable",
+    "usable_as_source": false,
+    "usable_as_target": true,
+    "features": {
+      "tone": {
+        "status": "stable"
+      },
+      "writing_style": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "es",
+    "name": "Spanish",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "fr",
+    "name": "French",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "it",
+    "name": "Italian",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "ja",
+    "name": "Japanese",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "ko",
+    "name": "Korean",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "pt",
+    "name": "Portuguese",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "pt-BR",
+    "name": "Portuguese (Brazilian)",
+    "status": "stable",
+    "usable_as_source": false,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "pt-PT",
+    "name": "Portuguese (European)",
+    "status": "stable",
+    "usable_as_source": false,
+    "usable_as_target": true,
+    "features": {}
+  },
+  {
+    "lang": "zh",
+    "name": "Chinese",
+    "status": "stable",
+    "usable_as_source": true,
+    "usable_as_target": true,
+    "features": {
+      "auto_detection": {
+        "status": "stable"
+      }
+    }
+  },
+  {
+    "lang": "zh-Hans",
+    "name": "Chinese (simplified)",
+    "status": "stable",
+    "usable_as_source": false,
+    "usable_as_target": true,
+    "features": {}
+  }
+]

--- a/scripts/fetch_v3_languages.py
+++ b/scripts/fetch_v3_languages.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Fetch v3/languages responses and write them to data/v3-languages/.
+
+Reads DEEPL_AUTH_KEY from the environment. By default uses the Pro
+endpoint; pass --free to hit api-free.deepl.com, or --base-url to point
+at any other host (e.g. a staging environment or local mock for
+testing). The DEEPL_API_BASE_URL environment variable does the same.
+
+The fetcher requests every resource with ?include=beta&include=external so
+the vended files contain the full superset of languages and features.
+Consumers filter client-side using the status field on languages/features.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+INCLUDES = ("beta", "external")
+DATA_DIR = Path(__file__).resolve().parent.parent / "data" / "v3-languages"
+PRO_URL = "https://api.deepl.com"
+FREE_URL = "https://api-free.deepl.com"
+
+
+def get(url: str, key: str) -> object:
+    req = urllib.request.Request(
+        url,
+        headers={
+            "Authorization": f"DeepL-Auth-Key {key}",
+            "Accept": "application/json",
+            "User-Agent": "deepl-api-docs-vendor/1.0",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return json.loads(resp.read())
+
+
+def fetch(base_url: str, key: str) -> dict[str, object]:
+    resources = get(f"{base_url}/v3/languages/resources", key)
+    if not isinstance(resources, list):
+        raise RuntimeError(f"Unexpected resources payload: {resources!r}")
+
+    out: dict[str, object] = {"resources.json": resources}
+    qs = urllib.parse.urlencode([("include", v) for v in INCLUDES], doseq=True)
+    for entry in resources:
+        name = entry["name"]
+        langs = get(f"{base_url}/v3/languages?resource={name}&{qs}", key)
+        out[f"{name}.json"] = langs
+    return out
+
+
+def write_files(payloads: dict[str, object], out_dir: Path) -> list[Path]:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    written: list[Path] = []
+    for filename, payload in payloads.items():
+        path = out_dir / filename
+        with path.open("w", encoding="utf-8") as f:
+            json.dump(payload, f, indent=2, ensure_ascii=False, sort_keys=False)
+            f.write("\n")
+        written.append(path)
+    return written
+
+
+def resolve_base_url(cli_base_url: str | None, free: bool) -> str:
+    if cli_base_url and free:
+        raise SystemExit("error: --base-url and --free are mutually exclusive")
+    if cli_base_url:
+        return cli_base_url.rstrip("/")
+    env_url = os.environ.get("DEEPL_API_BASE_URL")
+    if env_url:
+        return env_url.rstrip("/")
+    return FREE_URL if free else PRO_URL
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--base-url",
+        help=(
+            "API base URL to fetch from (e.g. https://api.example.test). "
+            "Overrides --free and the DEEPL_API_BASE_URL env var. "
+            f"Defaults to {PRO_URL}, or {FREE_URL} with --free."
+        ),
+    )
+    parser.add_argument(
+        "--free",
+        action="store_true",
+        help=f"Use {FREE_URL} instead of {PRO_URL}",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=DATA_DIR,
+        help=f"Output directory (default: {DATA_DIR})",
+    )
+    args = parser.parse_args()
+
+    key = os.environ.get("DEEPL_AUTH_KEY")
+    if not key:
+        print("error: DEEPL_AUTH_KEY is not set", file=sys.stderr)
+        return 2
+
+    base_url = resolve_base_url(args.base_url, args.free)
+    try:
+        payloads = fetch(base_url, key)
+    except urllib.error.HTTPError as e:
+        print(f"error: {e.code} {e.reason} from {e.url}", file=sys.stderr)
+        return 1
+
+    paths = write_files(payloads, args.out)
+    for p in paths:
+        print(p)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Commits the live responses from `/v3/languages` and `/v3/languages/resources` to `data/v3-languages/` (one file per resource plus `resources.json`), fetched against `api.deepl.com` with `?include=beta&include=external` so the vended data is the full superset.
- Adds `scripts/fetch_v3_languages.py` (stdlib-only) that refreshes every file using `DEEPL_AUTH_KEY`. Pass `--free` to hit `api-free.deepl.com`.
- Updates `.mintignore` so `data/` and `scripts/` are not picked up by Mintlify.

This is the first of three stacked PRs:
1. **This PR** — vend the responses.
2. Follow-up: hourly GitHub Action that refreshes these files and opens a PR on diff.
3. Follow-up: regenerate `snippets/language-table.jsx` from the vended JSON.

## Test plan
- [ ] Inspect `data/v3-languages/*.json` to confirm each resource is represented.
- [ ] Run `DEEPL_AUTH_KEY=... python3 scripts/fetch_v3_languages.py` locally; verify no diff against committed files (modulo any genuine upstream change).
- [ ] `mint dev` still serves the site (data files are ignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)