### PR TITLE
docs(openapi): document style_id, translation_memory_id, and translation_memory_threshold on POST /v2/document

### DIFF
--- a/api-reference/openapi.yaml
+++ b/api-reference/openapi.yaml
@@ -776,6 +776,21 @@ paths:
                   target_lang: DE
                   file: '@document.docx'
                   glossary_id: '[yourGlossaryId]'
+              StyleRule:
+                summary: Using a Style Rule List
+                value:
+                  source_lang: EN
+                  target_lang: DE
+                  file: '@document.docx'
+                  style_id: '[yourStyleId]'
+              TranslationMemory:
+                summary: Using a Translation Memory
+                value:
+                  source_lang: EN
+                  target_lang: DE
+                  file: '@document.docx'
+                  translation_memory_id: '[yourTranslationMemoryId]'
+                  translation_memory_threshold: 75
             schema:
               type: object
               required:
@@ -812,6 +827,17 @@ paths:
                   $ref: '#/components/schemas/Formality'
                 glossary_id:
                   $ref: '#/components/schemas/GlossaryId'
+                style_id:
+                  description: |-
+                    Specify the [style rule list](/api-reference/style-rules) to use for the translation.
+
+                    **Important:** The target language has to match the language of the style rule list.
+                  type: string
+                  example: 7ff9bfd6-cd85-4190-8503-d6215a321519
+                translation_memory_id:
+                  $ref: '#/components/schemas/TranslationMemoryId'
+                translation_memory_threshold:
+                  $ref: '#/components/schemas/TranslationMemoryThreshold'
                 enable_beta_languages:
                   description: |-
                     This parameter is maintained for backward compatibility and has no effect.

--- a/docs/resources/roadmap-and-release-notes.mdx
+++ b/docs/resources/roadmap-and-release-notes.mdx
@@ -11,6 +11,11 @@ rss: true
 </Update>
 
 <Update label="May 2026">
+## May 26 - Style Rules and Translation Memories for Document Translation
+- [`POST /v2/document`](/api-reference/document/upload-and-translate-a-document) now accepts `style_id`, `translation_memory_id`, and `translation_memory_threshold`, bringing document translation in line with the parameters already available on text translation.
+- `style_id` applies a configured [style rule list](/api-reference/style-rules) to the document translation.
+- `translation_memory_id` and `translation_memory_threshold` work as on text translation: pass a translation memory ID to apply stored translations, and set a threshold (0-100) to control how closely source text must match a stored segment. See the [translation memories guide](/docs/learning-how-tos/examples-and-guides/how-to-use-translation-memories).
+
 ## May 20 - Custom Tag Usage Analytics
 - Added [`GET /v2/admin/analytics/custom-tags`](/api-reference/admin-api/organization-usage-analytics) to the Admin API, allowing admins to retrieve usage statistics broken down by custom tags.
 - Supports `aggregate_by=period` (default) to aggregate usage over the full date range, or `aggregate_by=day` for daily breakdowns.


### PR DESCRIPTION
## Summary
- Document `style_id`, `translation_memory_id`, and `translation_memory_threshold` as multipart form fields on `POST /v2/document`, matching the parameters already exposed on `POST /v2/translate`.
- `translation_memory_id` and `translation_memory_threshold` reuse the existing component schemas; `style_id` is described inline (no `model_type` interaction note, since `/v2/document` does not expose `model_type`).
- Adds `StyleRule` and `TranslationMemory` examples to the request body, alongside the existing `Basic` and `Glossary` examples.

## Test plan
- [ ] `mint broken-links` passes
- [ ] `mint broken-links --check-anchors` passes
- [ ] OpenAPI playground renders the four examples and the three new properties on `POST /v2/document`