### PR TITLE
fix(supported-languages): pull write writing_style and tone languages automatically from vended v3/languages response

### DIFF
--- a/api-reference/improve-text.mdx
+++ b/api-reference/improve-text.mdx
@@ -93,15 +93,7 @@ curl -X POST 'https://api.deepl.com/v2/write/rephrase' \
   </Expandable>
   Currently supported for the following target languages:
 
-  * `de` (German)
-  * `en-GB` (British English)
-  * `en-US` (American English)
-  * `es` (Spanish)
-  * `fr` (French)
-  * `it` (Italian)
-  * `pt-BR` (Brazilian Portuguese)
-  * `pt-PT` (Portuguese)
-
+  <SupportedLanguages mode="bullets" resource="write" feature="writing_style" direction="target" />
 
   Styles prefixed with `prefer_` will fall back to the `default` style when used with a language that does not support styles (this is recommended for cases where no `target_lang` is set), the non-prefixed writing styles (except `default`) will return a HTTP 400 error in that case.
 
@@ -128,14 +120,7 @@ curl -X POST 'https://api.deepl.com/v2/write/rephrase' \
 
   Currently supported for the following target languages:
 
-  * `de` (German)
-  * `en-GB` (British English)
-  * `en-US` (American English)
-  * `es` (Spanish)
-  * `fr` (French)
-  * `it` (Italian)
-  * `pt-BR` (Brazilian Portuguese)
-  * `pt-PT` (Portuguese)
+  <SupportedLanguages mode="bullets" resource="write" feature="tone" direction="target" />
 
   Tones prefixed with `prefer_` will fall back to the `default` tone when used with a language that does not support tones (this is recommended for cases where no `target_lang` is set), the non-prefixed tones (except `default`) will return a HTTP 400 error in that case.
 


### PR DESCRIPTION
## Summary
Switches the `writing_style` and `tone` ParamFields in `api-reference/improve-text.mdx` from the hardcoded bullet lists back to `<SupportedLanguages mode="bullets" resource="write" feature="..." direction="target" />`, so both lists derive automatically from the vended `/v3/languages?resource=write` response.

**Blocked until the `write` response is correct.** The vended `write.json` currently only flags `writing_style` / `tone` on `de`, `en-GB`, `en-US`. The hardcoded list ships 8 languages (also `es`, `fr`, `it`, `pt-BR`, `pt-PT`). Merge this only after the API team has fixed the `/v3/languages?resource=write` response so the rendered list matches reality.

Stacked on #355.

## Test plan
- [ ] Once the API is fixed and `data/v3-languages/write.json` is refreshed, render `mint dev` → `/api-reference/improve-text` and confirm both `writing_style` and `tone` ParamFields list the expected target languages.
- [ ] Compare against the previously hardcoded list (`de`, `en-GB`, `en-US`, `es`, `fr`, `it`, `pt-BR`, `pt-PT`); flag any mismatch with the API team before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)