### PR TITLE
docs(openapi): document style_id, translation_memory_id, and translation_memory_threshold on POST /v2/document

### DIFF
--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -1050,6 +1050,25 @@
                     "file": "@document.docx",
                     "glossary_id": "[yourGlossaryId]"
                   }
+                },
+                "StyleRule": {
+                  "summary": "Using a Style Rule List",
+                  "value": {
+                    "source_lang": "EN",
+                    "target_lang": "DE",
+                    "file": "@document.docx",
+                    "style_id": "[yourStyleId]"
+                  }
+                },
+                "TranslationMemory": {
+                  "summary": "Using a Translation Memory",
+                  "value": {
+                    "source_lang": "EN",
+                    "target_lang": "DE",
+                    "file": "@document.docx",
+                    "translation_memory_id": "[yourTranslationMemoryId]",
+                    "translation_memory_threshold": 75
+                  }
                 }
               },
               "schema": {
@@ -1083,6 +1102,17 @@
                   },
                   "glossary_id": {
                     "$ref": "#/components/schemas/GlossaryId"
+                  },
+                  "style_id": {
+                    "description": "Specify the [style rule list](/api-reference/style-rules) to use for the translation.\n\n**Important:** The target language has to match the language of the style rule list.",
+                    "type": "string",
+                    "example": "7ff9bfd6-cd85-4190-8503-d6215a321519"
+                  },
+                  "translation_memory_id": {
+                    "$ref": "#/components/schemas/TranslationMemoryId"
+                  },
+                  "translation_memory_threshold": {
+                    "$ref": "#/components/schemas/TranslationMemoryThreshold"
                   },
                   "enable_beta_languages": {
                     "description": "This parameter is maintained for backward compatibility and has no effect.",

--- a/api-reference/openapi.yaml
+++ b/api-reference/openapi.yaml
@@ -787,6 +787,21 @@ paths:
                   target_lang: DE
                   file: '@document.docx'
                   glossary_id: '[yourGlossaryId]'
+              StyleRule:
+                summary: Using a Style Rule List
+                value:
+                  source_lang: EN
+                  target_lang: DE
+                  file: '@document.docx'
+                  style_id: '[yourStyleId]'
+              TranslationMemory:
+                summary: Using a Translation Memory
+                value:
+                  source_lang: EN
+                  target_lang: DE
+                  file: '@document.docx'
+                  translation_memory_id: '[yourTranslationMemoryId]'
+                  translation_memory_threshold: 75
             schema:
               type: object
               required:
@@ -823,6 +838,17 @@ paths:
                   $ref: '#/components/schemas/Formality'
                 glossary_id:
                   $ref: '#/components/schemas/GlossaryId'
+                style_id:
+                  description: |-
+                    Specify the [style rule list](/api-reference/style-rules) to use for the translation.
+
+                    **Important:** The target language has to match the language of the style rule list.
+                  type: string
+                  example: 7ff9bfd6-cd85-4190-8503-d6215a321519
+                translation_memory_id:
+                  $ref: '#/components/schemas/TranslationMemoryId'
+                translation_memory_threshold:
+                  $ref: '#/components/schemas/TranslationMemoryThreshold'
                 enable_beta_languages:
                   description: |-
                     This parameter is maintained for backward compatibility and has no effect.

--- a/docs/resources/roadmap-and-release-notes.mdx
+++ b/docs/resources/roadmap-and-release-notes.mdx
@@ -11,6 +11,11 @@ rss: true
 </Update>
 
 <Update label="June 2026">
+## June 8 - Style Rules and Translation Memories for Document Translation
+- [`POST /v2/document`](/api-reference/document/upload-and-translate-a-document) now accepts `style_id`, `translation_memory_id`, and `translation_memory_threshold`, bringing document translation in line with the parameters already available on text translation.
+- `style_id` applies a configured [style rule list](/api-reference/style-rules) to the document translation.
+- `translation_memory_id` and `translation_memory_threshold` work as on text translation: pass a translation memory ID to apply stored translations, and set a threshold (0-100) to control how closely source text must match a stored segment. See the [translation memories guide](/docs/learning-how-tos/examples-and-guides/how-to-use-translation-memories).
+
 ## June 3 - Docs MCP Server
 - DeepL's developer documentation now exposes an MCP server at `https://developers.deepl.com/mcp`.
 - This enables AI tools to search the docs directly and get source-grounded answers about the DeepL API, with no API key required.


### PR DESCRIPTION
## Summary
- Document `style_id`, `translation_memory_id`, and `translation_memory_threshold` as multipart form fields on `POST /v2/document`, matching the parameters already exposed on `POST /v2/translate`.
- `translation_memory_id` and `translation_memory_threshold` reuse the existing component schemas; `style_id` is described inline (no `model_type` interaction note, since `/v2/document` does not expose `model_type`).
- Adds `StyleRule` and `TranslationMemory` examples to the request body, alongside the existing `Basic` and `Glossary` examples.

## Test plan
- [ ] `mint broken-links` passes
- [ ] `mint broken-links --check-anchors` passes
- [ ] OpenAPI playground renders the four examples and the three new properties on `POST /v2/document`

---
Supersedes #354 (re-opened from an in-repo branch so the OpenAPI JSON auto-conversion workflow can run). Do not merge until the feature gate is tested and enabled on prod.