### PR TITLE
Add Docs MCP Server page

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -123,6 +123,7 @@
             "pages": [
               "docs/getting-started/deepl-cli",
               "docs/getting-started/deepl-mcp-server",
+              "docs/getting-started/docs-mcp-server",
               "docs/getting-started/test-your-api-requests-with-postman",
               "docs/resources/deepl-developer-community",
               "docs/resources/open-api-spec"

--- a/docs/getting-started/deepl-mcp-server.mdx
+++ b/docs/getting-started/deepl-mcp-server.mdx
@@ -15,10 +15,6 @@ The [DeepL MCP Server](https://github.com/DeepLcom/deepl-mcp-server) is an open-
 Looking to give your AI tool access to the DeepL documentation itself? See the [Docs MCP Server](/docs/getting-started/docs-mcp-server) for source-grounded answers about the DeepL API.
 </Tip>
 
-<Note>
-If you want to build a custom MCP server from scratch using the DeepL API, see the [MCP Server Cookbook](/docs/learning-how-tos/examples-and-guides/deepl-mcp-server-how-to-build-and-use-translation-in-llm-applications).
-</Note>
-
 ## Prerequisites
 
 - [Node.js](https://nodejs.org/) v18 or later

--- a/docs/getting-started/deepl-mcp-server.mdx
+++ b/docs/getting-started/deepl-mcp-server.mdx
@@ -11,6 +11,10 @@ public: true
 
 The [DeepL MCP Server](https://github.com/DeepLcom/deepl-mcp-server) is an open-source (MIT license) [Model Context Protocol](https://modelcontextprotocol.io/) server that gives AI agents access to DeepL's translation, text improvement, and glossary capabilities. MCP lets AI agents discover and call external tools through a standardized protocol — your agent sends a tool request to the MCP server, which calls the DeepL API and returns the result.
 
+<Tip>
+Looking to give your AI tool access to the DeepL documentation itself? See the [Docs MCP Server](/docs/getting-started/docs-mcp-server) for source-grounded answers about the DeepL API.
+</Tip>
+
 <Note>
 If you want to build a custom MCP server from scratch using the DeepL API, see the [MCP Server Cookbook](/docs/learning-how-tos/examples-and-guides/deepl-mcp-server-how-to-build-and-use-translation-in-llm-applications).
 </Note>

--- a/docs/getting-started/docs-mcp-server.mdx
+++ b/docs/getting-started/docs-mcp-server.mdx
@@ -1,0 +1,102 @@
+---
+title: "Docs MCP Server"
+description: "Connect your AI tools to the DeepL developer documentation for source-grounded answers about the DeepL API."
+---
+
+**This page shows you:**
+- What the DeepL Docs MCP Server is and how it differs from the [DeepL MCP Server](/docs/getting-started/deepl-mcp-server)
+- How to connect it to Claude, Cursor, VS Code, and other AI tools
+
+The DeepL developer documentation site exposes a [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) server at `https://developers.deepl.com/mcp`. This lets AI tools search and read our documentation directly, so they can give you accurate, up-to-date answers about the DeepL API without relying on training data.
+
+<Note>
+This is different from the [DeepL MCP Server](/docs/getting-started/deepl-mcp-server), which gives AI agents the ability to *call* the DeepL API (translate text, manage glossaries, etc.). The Docs MCP Server provides read-only access to the documentation itself.
+</Note>
+
+## What it provides
+
+When connected, your AI tool gets two capabilities:
+
+- **Search**: Find relevant documentation pages by keyword, returning snippets with titles and links
+- **Read**: Navigate and read full pages from the documentation site
+
+Your AI tool decides when to use each capability based on the conversation context. For example, if you ask "How do I use glossaries with the DeepL API?", the tool can search the docs, pull up the relevant pages, and give you an answer grounded in the actual documentation.
+
+## Setup
+
+<Tabs>
+<Tab title="Claude Desktop">
+
+1. Open Claude Desktop and go to **Settings > Connectors**
+2. Click **Add custom connector**
+3. Enter a name (e.g., "DeepL Docs") and the URL: `https://developers.deepl.com/mcp`
+4. In any chat, click the attachments icon and select the connector to activate it
+
+</Tab>
+<Tab title="Claude Code">
+
+Run this command to add the server:
+
+```bash
+claude mcp add --transport http deepl-docs https://developers.deepl.com/mcp
+```
+
+Claude Code can now search and reference DeepL documentation during your sessions.
+
+</Tab>
+<Tab title="Cursor">
+
+Open Command Palette (`Cmd+Shift+P` / `Ctrl+Shift+P`), search for "Open MCP Settings", and add the following to your `mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "deepl-docs": {
+      "url": "https://developers.deepl.com/mcp"
+    }
+  }
+}
+```
+
+</Tab>
+<Tab title="VS Code">
+
+Create a `.vscode/mcp.json` file in your project root:
+
+```json
+{
+  "servers": {
+    "deepl-docs": {
+      "type": "http",
+      "url": "https://developers.deepl.com/mcp"
+    }
+  }
+}
+```
+
+</Tab>
+<Tab title="Other MCP clients">
+
+Any MCP-compatible client can connect using the server URL:
+
+```
+https://developers.deepl.com/mcp
+```
+
+Refer to your client's documentation for how to add remote MCP servers.
+
+</Tab>
+</Tabs>
+
+No API key or authentication is required.
+
+## Example prompts
+
+Once connected, try asking your AI tool questions like:
+
+- "How do I translate a document using the DeepL API?"
+- "What parameters does the text translation endpoint accept?"
+- "How do glossaries work in DeepL?"
+- "What are the rate limits for the DeepL API?"
+
+The AI tool will search the documentation and return answers with references to specific pages.

--- a/docs/resources/roadmap-and-release-notes.mdx
+++ b/docs/resources/roadmap-and-release-notes.mdx
@@ -10,6 +10,12 @@ rss: true
 - Usage reporting by language pair
 </Update>
 
+<Update label="June 2026">
+## June 3 - Docs MCP Server
+- The DeepL developer documentation now exposes a [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) server at `https://developers.deepl.com/mcp`. Connect AI tools like Claude, Cursor, or VS Code to search and read the docs directly for source-grounded answers about the DeepL API.
+- No API key required. See the [Docs MCP Server](/docs/getting-started/docs-mcp-server) page for setup instructions.
+</Update>
+
 <Update label="May 2026">
 ## May 27 - Custom Reporting Tags in deepl-rb
 - The Ruby client library [`deepl-rb`](https://github.com/DeepLcom/deepl-rb) v3.8.0 now accepts an `additional_headers` argument on `translate` calls, so you can send `X-DeepL-Reporting-Tag` for usage reporting.

--- a/docs/resources/roadmap-and-release-notes.mdx
+++ b/docs/resources/roadmap-and-release-notes.mdx
@@ -12,7 +12,7 @@ rss: true
 
 <Update label="June 2026">
 ## June 3 - Docs MCP Server
-- The DeepL developer documentation now exposes a [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) server at `https://developers.deepl.com/mcp`. Connect AI tools like Claude, Cursor, or VS Code to search and read the docs directly for source-grounded answers about the DeepL API.
+- DeepL's developer documentation now exposes an [MCP](https://modelcontextprotocol.io/) server at `https://developers.deepl.com/mcp`. Connect AI tools like Claude, Cursor, or VS Code to search the API docs directly and get source-grounded answers about the DeepL API.
 - No API key required. See the [Docs MCP Server](/docs/getting-started/docs-mcp-server) page for setup instructions.
 </Update>
 

--- a/docs/resources/roadmap-and-release-notes.mdx
+++ b/docs/resources/roadmap-and-release-notes.mdx
@@ -12,8 +12,9 @@ rss: true
 
 <Update label="June 2026">
 ## June 3 - Docs MCP Server
-- DeepL's developer documentation now exposes an MCP server at `https://developers.deepl.com/mcp`. Connect AI tools like Claude, Cursor, or VS Code to search the API docs directly and get source-grounded answers about the DeepL API.
-- No API key required. See the [Docs MCP Server](/docs/getting-started/docs-mcp-server) page for setup instructions.
+- DeepL's developer documentation now exposes an MCP server at `https://developers.deepl.com/mcp`.
+- This enables AI tools to search the docs directly and get source-grounded answers about the DeepL API, with no API key required.
+- See the [Docs MCP Server](/docs/getting-started/docs-mcp-server) page for setup instructions.
 </Update>
 
 <Update label="May 2026">

--- a/docs/resources/roadmap-and-release-notes.mdx
+++ b/docs/resources/roadmap-and-release-notes.mdx
@@ -12,7 +12,7 @@ rss: true
 
 <Update label="June 2026">
 ## June 3 - Docs MCP Server
-- DeepL's developer documentation now exposes an [MCP](https://modelcontextprotocol.io/) server at `https://developers.deepl.com/mcp`. Connect AI tools like Claude, Cursor, or VS Code to search the API docs directly and get source-grounded answers about the DeepL API.
+- DeepL's developer documentation now exposes an MCP server at `https://developers.deepl.com/mcp`. Connect AI tools like Claude, Cursor, or VS Code to search the API docs directly and get source-grounded answers about the DeepL API.
 - No API key required. See the [Docs MCP Server](/docs/getting-started/docs-mcp-server) page for setup instructions.
 </Update>
 


### PR DESCRIPTION
## Summary
- Adds a new **Docs MCP Server** page (`docs/getting-started/docs-mcp-server.mdx`) documenting the Mintlify-provided MCP endpoint at `developers.deepl.com/mcp`, which lets AI tools search and read our developer documentation directly
- Includes setup instructions for Claude Desktop, Claude Code, Cursor, VS Code, and other MCP clients
- Adds a `<Tip>` callout on the existing DeepL MCP Server page cross-referencing the new page
- Updates `docs.json` navigation to include the new page under Developer Tools

## Test plan
- [ ] Preview the new page locally with `mint dev` at `/docs/getting-started/docs-mcp-server`
- [ ] Verify the cross-reference callout renders correctly on `/docs/getting-started/deepl-mcp-server`
- [ ] Confirm navigation shows the new page under Developer Tools
- [ ] Run `mint broken-links` to verify no broken links

🤖 Generated with [Claude Code](https://claude.com/claude-code)