### PR TITLE
fix(openapi): align glossary entries Accept and rephrase error responses with prod

### DIFF
--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -2528,9 +2528,6 @@
             "in": "header",
             "schema": {
               "type": "string",
-              "enum": [
-                "text/tab-separated-values"
-              ],
               "default": "text/tab-separated-values"
             },
             "description": "The requested format of the returned glossary entries. Currently, supports only `text/tab-separated-values`.",
@@ -2707,6 +2704,30 @@
                 }
               }
             }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "413": {
+            "$ref": "#/components/responses/PayloadTooLarge"
+          },
+          "415": {
+            "description": "Unsupported Content-Type. Use `application/json` or `application/x-www-form-urlencoded`."
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          },
+          "456": {
+            "$ref": "#/components/responses/QuotaExceeded"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          },
+          "504": {
+            "$ref": "#/components/responses/ServiceUnavailable"
           }
         },
         "security": [

--- a/api-reference/openapi.yaml
+++ b/api-reference/openapi.yaml
@@ -1781,8 +1781,6 @@ paths:
           in: header
           schema:
             type: string
-            enum:
-              - text/tab-separated-values
             default: text/tab-separated-values
           description: The requested format of the returned glossary entries. Currently,
             supports only `text/tab-separated-values`.
@@ -1901,6 +1899,22 @@ paths:
                           description: The improved text.
                           type: string
                           example: This is a sample sentence to improve.
+        400:
+          $ref: '#/components/responses/BadRequest'
+        403:
+          $ref: '#/components/responses/Forbidden'
+        413:
+          $ref: '#/components/responses/PayloadTooLarge'
+        415:
+          description: Unsupported Content-Type. Use `application/json` or `application/x-www-form-urlencoded`.
+        429:
+          $ref: '#/components/responses/TooManyRequests'
+        456:
+          $ref: '#/components/responses/QuotaExceeded'
+        500:
+          $ref: '#/components/responses/InternalServerError'
+        504:
+          $ref: '#/components/responses/ServiceUnavailable'
       security:
         - auth_header: [ ]
   /v2/write/correct:


### PR DESCRIPTION
## What

Two prod-verified spec corrections, surfaced while running the SDK test suites against deepl-mock with OpenAPI request/response validation enabled.

### 1. `GET /v2/glossaries/{glossary_id}/entries` — relax the `Accept` header
The parameter declared a single-value `enum: [text/tab-separated-values]`, so OpenAPI request-validation rejected the ordinary `Accept: */*` that clients send. Verified against `api.deepl.com`:

| Accept | Prod |
| --- | --- |
| `*/*` | 200 + TSV |
| `text/tab-separated-values` | 200 + TSV |
| `application/json` | 415 |

Dropping the `enum` (keeping the `default`) matches prod's content negotiation; the existing `415` response already covers the unsupported case.

### 2. `POST /v2/write/rephrase` — document error responses
Only `200` was declared, so spec-validating tooling treats any error as undocumented. Added the same error set as its sibling `/v2/write/correct` (`400/403/413/415/429/456/500/504`). Verified against prod: `400` (invalid params), `403` (invalid key), `415` (unsupported content-type).

## Notes
- `openapi.json` is regenerated from YAML by the existing workflow.
- No behavior change to the API; this aligns the documented contract with what production already does.