### PR TITLE
docs: remove latency_optimized restrictions and add release note

### DIFF
--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -799,7 +799,7 @@
                     "$ref": "#/components/schemas/TranslationMemoryThreshold"
                   },
                   "custom_instructions": {
-                    "description": "Specify a list of instructions to customize the translation behavior. Up to 10 custom instructions can be specified, each with a maximum of 300 characters.\n\n**Important:**  The target language must be `de`, `en`, `es`, `fr`, `it`, `ja`, `ko`, `zh` or any variants of these languages.\n\n**Note:** Any request with the `custom_instructions` parameter enabled will default to use the `quality_optimized` model type. All `model_type` values are supported.",
+                    "description": "Specify a list of instructions to customize the translation behavior. Up to 10 custom instructions can be specified, each with a maximum of 300 characters.\n\n**Important:**  The target language must be `de`, `en`, `es`, `fr`, `it`, `ja`, `ko`, `zh` or any variants of these languages.\n\nWhen no `model_type` is specified, requests with `custom_instructions` default to `quality_optimized`. All `model_type` values are supported.",
                     "type": "array",
                     "items": {
                       "type": "string",

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -788,7 +788,7 @@
                     "example": "def3a26b-3e84-45b3-84ae-0c0aaf3525f7"
                   },
                   "style_id": {
-                    "description": "Specify the [style rule list](/api-reference/style-rules) to use for the translation.\n\n**Important:**  The target language has to match the language of the style rule list.\n\nWhen no `model_type` is specified, requests with the `style_id` parameter default to `quality_optimized`. All `model_type` values are supported.",
+                    "description": "Specify the [style rule list](/api-reference/style-rules) to use for the translation.\n\n**Important:**  The target language has to match the language of the style rule list.",
                     "type": "string",
                     "example": "7ff9bfd6-cd85-4190-8503-d6215a321519"
                   },
@@ -799,7 +799,7 @@
                     "$ref": "#/components/schemas/TranslationMemoryThreshold"
                   },
                   "custom_instructions": {
-                    "description": "Specify a list of instructions to customize the translation behavior. Up to 10 custom instructions can be specified, each with a maximum of 300 characters.\n\n**Important:**  The target language must be `de`, `en`, `es`, `fr`, `it`, `ja`, `ko`, `zh` or any variants of these languages.\n\nWhen no `model_type` is specified, requests with `custom_instructions` default to `quality_optimized`. All `model_type` values are supported.",
+                    "description": "Specify a list of instructions to customize the translation behavior. Up to 10 custom instructions can be specified, each with a maximum of 300 characters.\n\n**Important:**  The target language must be `de`, `en`, `es`, `fr`, `it`, `ja`, `ko`, `zh` or any variants of these languages.",
                     "type": "array",
                     "items": {
                       "type": "string",
@@ -7685,7 +7685,7 @@
       "TranslationMemoryId": {
         "type": "string",
         "format": "uuid",
-        "description": "A unique ID assigned to a translation memory.\n\nWhen no `model_type` is specified, requests with `translation_memory_id` default to `quality_optimized`. All `model_type` values are supported.",
+        "description": "A unique ID assigned to a translation memory.",
         "example": "a74d88fb-ed2a-4943-a664-a4512398b994"
       },
       "TranslationMemorySourceLanguage": {

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -788,7 +788,7 @@
                     "example": "def3a26b-3e84-45b3-84ae-0c0aaf3525f7"
                   },
                   "style_id": {
-                    "description": "Specify the [style rule list](/api-reference/style-rules) to use for the translation.\n\n**Important:**  The target language has to match the language of the style rule list.",
+                    "description": "Specify the [style rule list](/api-reference/style-rules) to use for the translation.\n\n**Important:**  The target language has to match the language of the style rule list.\n\nAll `model_type` values are supported.",
                     "type": "string",
                     "example": "7ff9bfd6-cd85-4190-8503-d6215a321519"
                   },

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -788,7 +788,7 @@
                     "example": "def3a26b-3e84-45b3-84ae-0c0aaf3525f7"
                   },
                   "style_id": {
-                    "description": "Specify the [style rule list](/api-reference/style-rules) to use for the translation.\n\n**Important:**  The target language has to match the language of the style rule list.\n\n**Note:** Any request with the `style_id` parameter enabled will use `quality_optimized` models. Requests combining `style_id` and `model_type: latency_optimized` will be rejected.",
+                    "description": "Specify the [style rule list](/api-reference/style-rules) to use for the translation.\n\n**Important:**  The target language has to match the language of the style rule list.\n\nWhen no `model_type` is specified, requests with the `style_id` parameter default to `quality_optimized`. All `model_type` values are supported.",
                     "type": "string",
                     "example": "7ff9bfd6-cd85-4190-8503-d6215a321519"
                   },
@@ -799,7 +799,7 @@
                     "$ref": "#/components/schemas/TranslationMemoryThreshold"
                   },
                   "custom_instructions": {
-                    "description": "Specify a list of instructions to customize the translation behavior. Up to 10 custom instructions can be specified, each with a maximum of 300 characters.\n\n**Important:**  The target language must be `de`, `en`, `es`, `fr`, `it`, `ja`, `ko`, `zh` or any variants of these languages.\n\n**Note:** Any request with the `custom_instructions` parameter enabled will default to use the `quality_optimized` model type. Requests combining `custom_instructions` and `model_type: latency_optimized` will be rejected.",
+                    "description": "Specify a list of instructions to customize the translation behavior. Up to 10 custom instructions can be specified, each with a maximum of 300 characters.\n\n**Important:**  The target language must be `de`, `en`, `es`, `fr`, `it`, `ja`, `ko`, `zh` or any variants of these languages.\n\n**Note:** Any request with the `custom_instructions` parameter enabled will default to use the `quality_optimized` model type. All `model_type` values are supported.",
                     "type": "array",
                     "items": {
                       "type": "string",
@@ -7685,7 +7685,7 @@
       "TranslationMemoryId": {
         "type": "string",
         "format": "uuid",
-        "description": "A unique ID assigned to a translation memory.\n\n**Note:** Requests with the `translation_memory_id` parameter must use the `quality_optimized` model type. Requests combining `translation_memory_id` and `model_type: latency_optimized` will be rejected.",
+        "description": "A unique ID assigned to a translation memory.\n\nWhen no `model_type` is specified, requests with `translation_memory_id` default to `quality_optimized`. All `model_type` values are supported.",
         "example": "a74d88fb-ed2a-4943-a664-a4512398b994"
       },
       "TranslationMemorySourceLanguage": {

--- a/api-reference/openapi.yaml
+++ b/api-reference/openapi.yaml
@@ -586,7 +586,7 @@ paths:
 
                     **Important:**  The target language has to match the language of the style rule list.
 
-                    When no `model_type` is specified, requests with the `style_id` parameter default to `quality_optimized`. All `model_type` values are supported.
+                    All `model_type` values are supported.
                   type: string
                   example: 7ff9bfd6-cd85-4190-8503-d6215a321519
                 translation_memory_id:
@@ -598,8 +598,6 @@ paths:
                     Specify a list of instructions to customize the translation behavior. Up to 10 custom instructions can be specified, each with a maximum of 300 characters.
 
                     **Important:**  The target language must be `de`, `en`, `es`, `fr`, `it`, `ja`, `ko`, `zh` or any variants of these languages.
-
-                    When no `model_type` is specified, requests with `custom_instructions` default to `quality_optimized`. All `model_type` values are supported.
                   type: array
                   items:
                     type: string
@@ -5517,8 +5515,6 @@ components:
       format: uuid
       description: |-
         A unique ID assigned to a translation memory.
-
-        When no `model_type` is specified, requests with `translation_memory_id` default to `quality_optimized`. All `model_type` values are supported.
       example: a74d88fb-ed2a-4943-a664-a4512398b994
     TranslationMemorySourceLanguage:
       description: The source language of the translation memory.

--- a/api-reference/openapi.yaml
+++ b/api-reference/openapi.yaml
@@ -586,7 +586,7 @@ paths:
 
                     **Important:**  The target language has to match the language of the style rule list.
 
-                    **Note:** Any request with the `style_id` parameter enabled will use `quality_optimized` models. Requests combining `style_id` and `model_type: latency_optimized` will be rejected.
+                    When no `model_type` is specified, requests with the `style_id` parameter default to `quality_optimized`. All `model_type` values are supported.
                   type: string
                   example: 7ff9bfd6-cd85-4190-8503-d6215a321519
                 translation_memory_id:
@@ -599,7 +599,7 @@ paths:
 
                     **Important:**  The target language must be `de`, `en`, `es`, `fr`, `it`, `ja`, `ko`, `zh` or any variants of these languages.
 
-                    **Note:** Any request with the `custom_instructions` parameter enabled will default to use the `quality_optimized` model type. Requests combining `custom_instructions` and `model_type: latency_optimized` will be rejected.
+                    When no `model_type` is specified, requests with `custom_instructions` default to `quality_optimized`. All `model_type` values are supported.
                   type: array
                   items:
                     type: string
@@ -5518,7 +5518,7 @@ components:
       description: |-
         A unique ID assigned to a translation memory.
 
-        **Note:** Requests with the `translation_memory_id` parameter must use the `quality_optimized` model type. Requests combining `translation_memory_id` and `model_type: latency_optimized` will be rejected.
+        When no `model_type` is specified, requests with `translation_memory_id` default to `quality_optimized`. All `model_type` values are supported.
       example: a74d88fb-ed2a-4943-a664-a4512398b994
     TranslationMemorySourceLanguage:
       description: The source language of the translation memory.

--- a/api-reference/style-rules.mdx
+++ b/api-reference/style-rules.mdx
@@ -936,5 +936,5 @@ curl -X POST 'https://api.deepl.com/v2/translate' \
 ```
 
 <Info>
-  Any request with the `style_id` parameter enabled will use `quality_optimized` models. Requests combining `style_id` and `model_type: latency_optimized` will be rejected.
+  When no `model_type` is specified, requests with the `style_id` parameter default to `quality_optimized`. All `model_type` values are supported.
 </Info>

--- a/api-reference/style-rules.mdx
+++ b/api-reference/style-rules.mdx
@@ -936,5 +936,5 @@ curl -X POST 'https://api.deepl.com/v2/translate' \
 ```
 
 <Info>
-  When no `model_type` is specified, requests with the `style_id` parameter default to `quality_optimized`. All `model_type` values are supported.
+  All `model_type` values are supported with style rules.
 </Info>

--- a/api-reference/translate.mdx
+++ b/api-reference/translate.mdx
@@ -221,9 +221,7 @@ Note that we do not include examples for our client libraries in every single se
   </Warning>
 
   <Info>
-    [Tag handling v2](/docs/xml-and-html-handling/tag-handling-v2) is compatible only with next-gen models and implicitly sets
-`model_type` to `quality_optimized`. Setting both `model_type=latency_optimized` and `tag_handling_version=v2` will return an
-error.
+    [Tag handling v2](/docs/xml-and-html-handling/tag-handling-v2) uses next-gen models and is compatible with all `model_type` values.
   </Info>
 
   See [About the model_type parameter](#about-the-model_type-parameter) for more details.
@@ -290,7 +288,7 @@ error.
   <Info>
     The target language has to match the language of the style rule list.
 
-    Additionally, any request with the `style_id` parameter enabled will default to use the `quality_optimized` model type. Requests combining `style_id` and `model_type: latency_optimized` will be rejected.
+    When no `model_type` is specified, requests with the `style_id` parameter default to `quality_optimized`. All `model_type` values are supported.
   </Info>
 </ParamField>
 <ParamField body="custom_instructions" type="array[string]">
@@ -299,14 +297,14 @@ error.
   <Info>
     The target language must be `de`, `en`, `es`, `fr`, `it`, `ja`, `ko`, `zh` or any variants of these languages.
 
-    Any request with the `custom_instructions` parameter enabled will default to use the `quality_optimized` model type. Requests combining `custom_instructions` and `model_type: latency_optimized` will be rejected. You can find best practices on how to write custom instructions [here](/docs/best-practices/custom-instructions).
+    When no `model_type` is specified, requests with `custom_instructions` default to `quality_optimized`. All `model_type` values are supported. You can find best practices on how to write custom instructions [here](/docs/best-practices/custom-instructions).
   </Info>
   To check language support dynamically, call <a href="/api-reference/languages/retrieve-supported-languages-by-resource"><code>GET /v3/languages?resource=translate_text</code></a> and check for the <code>style_rules</code> feature key on the target language.
 </ParamField>
 <ParamField body="translation_memory_id" type="string">
   The [translation memory](/api-reference/translation-memory/list-translation-memories) to use for the translation. The value should be the UUID of a translation memory associated with your account.
   <Info>
-    Requests with the `translation_memory_id` parameter must use the `quality_optimized` model type. Requests combining `translation_memory_id` and `model_type: latency_optimized` will be rejected.
+    When no `model_type` is specified, requests with `translation_memory_id` default to `quality_optimized`. All `model_type` values are supported.
   </Info>
 </ParamField>
 <ParamField body="translation_memory_threshold" type="integer">

--- a/api-reference/translate.mdx
+++ b/api-reference/translate.mdx
@@ -284,7 +284,6 @@ Note that we do not include examples for our client libraries in every single se
   <Info>
     The target language has to match the language of the style rule list.
 
-    When no `model_type` is specified, requests with the `style_id` parameter default to `quality_optimized`. All `model_type` values are supported.
   </Info>
 </ParamField>
 <ParamField body="custom_instructions" type="array[string]">
@@ -293,15 +292,12 @@ Note that we do not include examples for our client libraries in every single se
   <Info>
     The target language must be `de`, `en`, `es`, `fr`, `it`, `ja`, `ko`, `zh` or any variants of these languages.
 
-    When no `model_type` is specified, requests with `custom_instructions` default to `quality_optimized`. All `model_type` values are supported. You can find best practices on how to write custom instructions [here](/docs/best-practices/custom-instructions).
+    You can find best practices on how to write custom instructions [here](/docs/best-practices/custom-instructions).
   </Info>
   To check language support dynamically, call <a href="/api-reference/languages/retrieve-supported-languages-by-resource"><code>GET /v3/languages?resource=translate_text</code></a> and check for the <code>style_rules</code> feature key on the target language.
 </ParamField>
 <ParamField body="translation_memory_id" type="string">
   The [translation memory](/api-reference/translation-memory/list-translation-memories) to use for the translation. The value should be the UUID of a translation memory associated with your account.
-  <Info>
-    When no `model_type` is specified, requests with `translation_memory_id` default to `quality_optimized`. All `model_type` values are supported.
-  </Info>
 </ParamField>
 <ParamField body="translation_memory_threshold" type="integer">
   The minimum matching percentage required for a translation memory segment to be applied (recommended to be 75% or higher). Accepts values from 0 to 100. Default: `75`.
@@ -380,7 +376,7 @@ Note that we do not include examples for our client libraries in every single se
 ### About the model\_type parameter
 
 The `model_type` parameter lets a user specify if they would like to optimize for speed until a request is served (latency) or translation quality. This is done on a best-effort basis by DeepL, not every language pair and feature must behave differently depending on this parameter.
-Currently, the DeepL translation API defaults to the classic models if no `model_type` is included in the requests, except for certain languages (e.g. Thai, which is next-gen only) or certain features (e.g. tag handling v2, which only allows `quality_optimized`).
+Currently, the DeepL translation API defaults to `latency_optimized` if no `model_type` is included in the request. All features and language pairs are compatible with all `model_type` values.
 Note that the API intentionally does not allow the user to specify a model, but rather their goal, so that the DeepL backend can choose the most suitable model for the user (this avoids users constantly having to update their code with new model versions and learning many different models name and their specifics).
 
 As of December 2025, all source and target languages are supported by next-gen models. Please note that DeepL reserves the right to quietly change which model serves e.g. a `model_type=quality_optimized` request, as long as we think it is a net benefit to the user (e.g. no significant latency increase, but a quality increase, or a significant latency reduction with no or only very slight decrease in quality).

--- a/api-reference/translate.mdx
+++ b/api-reference/translate.mdx
@@ -220,10 +220,6 @@ Note that we do not include examples for our client libraries in every single se
     To ensure accurate automatic language detection, the API uses next-gen models for all requests that omit `source_lang`, regardless of `model_type`. If your source language is known, you can specify `source_lang` to allow classic models to be used where available for your language pair. See [supported languages](/docs/getting-started/supported-languages) for language-specific model availability.
   </Warning>
 
-  <Info>
-    [Tag handling v2](/docs/xml-and-html-handling/tag-handling-v2) uses next-gen models and is compatible with all `model_type` values.
-  </Info>
-
   See [About the model_type parameter](#about-the-model_type-parameter) for more details.
 </ParamField>
 <ParamField body="split_sentences" type="string">

--- a/docs/best-practices/custom-instructions.mdx
+++ b/docs/best-practices/custom-instructions.mdx
@@ -85,7 +85,7 @@ When using custom instructions, keep these constraints in mind:
 - **Maximum instructions**: Up to 10 custom instructions per request
 - **Character limit**: Each instruction can contain a maximum of 300 characters
 - **Supported target languages**: `de`, `en`, `es`, `fr`, `it`, `ja`, `ko`, `zh`, or any variants of these languages
-- **Model behavior**: When `custom_instructions` are included and no `model_type` is specified, the API uses `quality_optimized` models. You can also explicitly set `model_type` to `latency_optimized` or `quality_optimized`.
+- **Model compatibility**: Custom instructions are compatible with all `model_type` values.
 
 ## Related documentation
 

--- a/docs/best-practices/custom-instructions.mdx
+++ b/docs/best-practices/custom-instructions.mdx
@@ -85,11 +85,7 @@ When using custom instructions, keep these constraints in mind:
 - **Maximum instructions**: Up to 10 custom instructions per request
 - **Character limit**: Each instruction can contain a maximum of 300 characters
 - **Supported target languages**: `de`, `en`, `es`, `fr`, `it`, `ja`, `ko`, `zh`, or any variants of these languages
-- **Model requirement**: Requests with `custom_instructions` automatically use the `quality_optimized` model type
-
-<Warning>
-Combining `custom_instructions` with `model_type: latency_optimized` will result in an error. Custom instructions require the quality-optimized model.
-</Warning>
+- **Model behavior**: When `custom_instructions` are included and no `model_type` is specified, the API uses `quality_optimized` models. You can also explicitly set `model_type` to `latency_optimized` or `quality_optimized`.
 
 ## Related documentation
 

--- a/docs/learning-how-tos/examples-and-guides/translation-beginners-guide.mdx
+++ b/docs/learning-how-tos/examples-and-guides/translation-beginners-guide.mdx
@@ -820,7 +820,7 @@ If you omit the `model_type`, the API normally defaults to `latency_optimized`.
 ### Special cases
 
 * If your request omits the `source_lang`, the API will use next-generation models to ensure the best possible language detection.  
-* [tag handling v2](/docs/xml-and-html-handling/tag-handling-v2#whats-new-in-v2) requires next-generation models. Setting both `model_type=latency_optimized` and `tag_handling_version=v2` yields an error.  
+* [tag handling v2](/docs/xml-and-html-handling/tag-handling-v2#whats-new-in-v2) uses next-generation models. It is compatible with all `model_type` values.  
 * For some languages, like Thai, the API uses the same model, regardless of requested `model_type`. This behavior may change as our models evolve.
 
 ## Limits

--- a/docs/resources/roadmap-and-release-notes.mdx
+++ b/docs/resources/roadmap-and-release-notes.mdx
@@ -10,6 +10,15 @@ rss: true
 </Update>
 
 <Update label="June 2026">
+## June 17 - `latency_optimized` Now Supported for All Features
+- The `latency_optimized` model type is now fully compatible with all Translate API features, including:
+  - [Tag handling v2](/docs/xml-and-html-handling/tag-handling-v2) (`tag_handling_version=v2`)
+  - [Style rules](/api-reference/style-rules) (`style_id`)
+  - [Custom instructions](/docs/best-practices/custom-instructions) (`custom_instructions`)
+  - [Translation memories](/docs/learning-how-tos/examples-and-guides/how-to-use-translation-memories) (`translation_memory_id`)
+  - All language pairs, including languages previously restricted to `quality_optimized`
+- Previously, combining `model_type=latency_optimized` with these features would return an error. These restrictions have been removed.
+
 ## June 15 - API Key Permissions (Private Beta)
 - Developer API keys can now be scoped to specific endpoints, so a key can be limited to, for example, translating text or reading glossaries. See [API key permissions](/docs/getting-started/managing-api-keys#api-key-permissions).
 - Assign one or more scopes when [creating or editing a key](https://www.deepl.com/your-account/keys). A scoped key returns `403 Forbidden` on any endpoint its scopes don't cover.
@@ -133,7 +142,7 @@ Use the `DeepL-Auth-Key` header instead.
 
 ## January 8 - 81 New Languages in GA
 - Promoted all 81 beta languages to standard language support. These languages are now part of the main source and target language lists.
-- Note that these languages only work with `quality_optimized` model or when no model is specified, and are not compatible with `latency_optimized` requests.
+- These languages are compatible with all `model_type` values including `latency_optimized`.
 - The `enable_beta_languages` parameter is maintained for backward compatibility but has no effect.
 
 See [here](../getting-started/supported-languages) for the complete language list.

--- a/docs/xml-and-html-handling/tag-handling-v2.mdx
+++ b/docs/xml-and-html-handling/tag-handling-v2.mdx
@@ -112,18 +112,12 @@ Only XML is strictly parsed. HTML is not strictly parsed.
 
 ## Compatibility
 
-Tag handling v2 is currently only compatible with the `quality_optimized` model type. Support for `latency_optimized` will be added in a future update.
+Tag handling v2 is compatible with all model types.
 
 | Model Type | v1 Support | v2 Support |
 |------------|:----------:|:----------:|
 | `quality_optimized` | ✅ | ✅ |
-| `latency_optimized` | ✅ | ❌ |
-
-When you set `tag_handling_version` to `v2`, the `model_type` is implicitly set to `quality_optimized`.
-
-<Warning>
-  Requests that specify both `model_type=latency_optimized` and `tag_handling_version=v2` will return an error.
-</Warning>
+| `latency_optimized` | ✅ | ✅ |
 
 ## Migration Guide
 


### PR DESCRIPTION
## Summary

  Removes all documentation stating that `model_type=latency_optimized` is incompatible with certain features. `latency_optimized` is now fully supported with all Translate API
  features.

  ## Changes across 8 files

  ### Restrictions removed:
  - **Tag handling v2**: Was "not compatible with latency_optimized" → now compatible
  - **Style rules** (`style_id`): Was "will be rejected" → now supported
  - **Custom instructions**: Was "will result in an error" → now supported
  - **Translation memories**: Was "will be rejected" → now supported
  - **81 new languages (Jan 2026)**: Was "not compatible with latency_optimized" → now compatible

  ### Files changed:
  - `api-reference/translate.mdx` — Updated parameter descriptions for style_id, custom_instructions, translation_memory_id, and tag_handling_version
  - `api-reference/style-rules.mdx` — Updated style_id info box
  - `api-reference/openapi.json` — Updated schema descriptions
  - `api-reference/openapi.yaml` — Updated schema descriptions
  - `docs/xml-and-html-handling/tag-handling-v2.mdx` — Updated compatibility table and removed warning
  - `docs/best-practices/custom-instructions.mdx` — Removed error warning
  - `docs/learning-how-tos/examples-and-guides/translation-beginners-guide.mdx` — Updated special cases
  - `docs/resources/roadmap-and-release-notes.mdx` — Added June 15 release note + updated Jan 8 note

  ### Release note added:
  June 15 entry announcing `latency_optimized` is now supported for all features, listing the specific features that were previously restricted.

  ## Context

  This is the documentation counterpart to the Dynamic Workflows migration work. The DW workflow code now handles `latency_optimized` with all features via the
  `split_mode_follows_requested_model_type` flag (dynamic-workflows!2111 and follow-ups).

  🤖 Generated with [Claude Code](https://claude.com/claude-code)