### PR TITLE
spec: add translation_memory resource and missing v3/languages/resour…

### DIFF
--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -3300,7 +3300,8 @@
                           "glossary",
                           "voice",
                           "write",
-                          "style_rules"
+                          "style_rules",
+                          "translation_memory"
                         ],
                         "example": "translate_text"
                       },
@@ -3323,7 +3324,11 @@
                                 "glossary",
                                 "writing_style",
                                 "tone",
-                                "auto_detection"
+                                "auto_detection",
+                                "transcription",
+                                "translated_speech",
+                                "spoken_terms",
+                                "translation_memory"
                               ]
                             },
                             "needs_source_support": {
@@ -3433,12 +3438,13 @@
                 "glossary",
                 "voice",
                 "write",
-                "style_rules"
+                "style_rules",
+                "translation_memory"
               ]
             },
             "example": "translate_text",
             "x-default": "translate_text",
-            "description": "The resource to retrieve languages for. Supported values: `translate_text`, `translate_document`,\n`glossary`, `voice`, `write`, `style_rules`."
+            "description": "The resource to retrieve languages for. Supported values: `translate_text`, `translate_document`,\n`glossary`, `voice`, `write`, `style_rules`, `translation_memory`."
           },
           {
             "name": "include",

--- a/api-reference/openapi.yaml
+++ b/api-reference/openapi.yaml
@@ -2298,6 +2298,7 @@ paths:
                         - voice
                         - write
                         - style_rules
+                        - translation_memory
                       example: translate_text
                     features:
                       description: |-
@@ -2320,6 +2321,10 @@ paths:
                               - writing_style
                               - tone
                               - auto_detection
+                              - transcription
+                              - translated_speech
+                              - spoken_terms
+                              - translation_memory
                           needs_source_support:
                             description: If `true`, the source language must support this feature for it to be available. Defaults to `false` if absent.
                             type: boolean
@@ -2385,11 +2390,12 @@ paths:
               - voice
               - write
               - style_rules
+              - translation_memory
           example: translate_text
           x-default: translate_text
           description: |-
             The resource to retrieve languages for. Supported values: `translate_text`, `translate_document`,
-            `glossary`, `voice`, `write`, `style_rules`.
+            `glossary`, `voice`, `write`, `style_rules`, `translation_memory`.
         - name: include
           in: query
           required: false


### PR DESCRIPTION
## What

`GET /v3/languages` and `GET /v3/languages/resources` had drifted from the live API. This extends three enums to match what `api.deepl.com` actually returns:

- `resource` query parameter enum (`/v3/languages`): add `translation_memory`
- `/v3/languages/resources` resource-name enum: add `translation_memory`
- `/v3/languages/resources` feature-name enum: add `transcription`, `translated_speech`, `spoken_terms`, `translation_memory`

No API behavior change. This only aligns the published spec with the responses the live API already serves.

## Evidence (live api.deepl.com)

`translation_memory` is a valid resource the current spec enum rejects:

```
$ curl '.../v3/languages?resource=translation_memory'
[
  { "lang": "de", "name": "German", "status": "stable",
    "usable_as_source": true, "usable_as_target": true, "features": {} },
  { "lang": "de-DE", "name": "German", "status": "stable",
    "usable_as_source": false, "usable_as_target": true, "features": {} },
  ...
]
```

`/v3/languages/resources` returns feature names not in the current enum (voice's `spoken_terms` / `transcription` / `translated_speech`, plus `translation_memory` as a resource):

```
$ curl '.../v3/languages/resources'
[
  ...
  { "name": "voice", "features": [
      { "name": "auto_detection",    "needs_source_support": true },
      { "name": "formality",         "needs_target_support": true },
      { "name": "glossary",          "needs_source_support": true, "needs_target_support": true },
      { "name": "spoken_terms",      "needs_source_support": true },
      { "name": "transcription",     "needs_source_support": true },
      { "name": "translated_speech", "needs_target_support": true }
  ] },
  { "name": "translation_memory", "features": [] }
]
```

## Notes

- YAML only; `openapi.json` is regenerated by the workflow.
