### PR TITLE
docs: Announce API key permissions general availability

### DIFF
--- a/docs/getting-started/managing-api-keys.mdx
+++ b/docs/getting-started/managing-api-keys.mdx
@@ -105,15 +105,13 @@ It's possible to set an API key-level limit to 0, which means the API key will n
 
 ### API key permissions
 
-<Warning>
-  **Private beta.** This feature is currently available to select customers only. To request access, contact your customer success manager or [DeepL support](https://support.deepl.com/hc/en-us/requests/new).
-</Warning>
-
 API key permissions let you limit what a developer API key can do. Instead of one key with full access to every endpoint, you can issue keys that are scoped to specific operations, for example a key that can only translate text or a key that can only read glossaries.
 
 Permissions are implemented as scopes. Each scope groups a set of related operations into a single capability you can grant to a key. This section uses "permissions" for the user-facing feature and "scopes" for the technical mechanism.
 
 Permissions are currently supported only for developer API keys. An account can hold any mix of scoped and unrestricted developer keys.
+
+API key permissions are available on the API Pro, API Developer, API Growth, and API Enterprise plans.
 
 **When to use scoped keys**
 

--- a/docs/getting-started/managing-api-keys.mdx
+++ b/docs/getting-started/managing-api-keys.mdx
@@ -105,7 +105,7 @@ It's possible to set an API key-level limit to 0, which means the API key will n
 
 ### API key permissions
 
-API key permissions let you limit what a developer API key can do. Instead of one key with full access to every endpoint, you can issue keys that are scoped to specific operations, for example a key that can only translate text or a key that can only read glossaries.
+API key permissions, introduced in June 2026, let you limit what a developer API key can do. Instead of one key with full access to every endpoint, you can issue keys that are scoped to specific operations, for example a key that can only translate text or a key that can only read glossaries.
 
 Permissions are implemented as scopes. Each scope groups a set of related operations into a single capability you can grant to a key. This section uses "permissions" for the user-facing feature and "scopes" for the technical mechanism.
 
@@ -119,6 +119,8 @@ API key permissions are available on the API Pro, API Developer, API Growth, and
 | --- | --- |
 | **Unrestricted** | A key can access any endpoint and doesn't need to be limited in any way. |
 | **Scoped** | A key should have access only to specific endpoints, for example to prevent glossaries from being modified inadvertently. |
+
+Before API key permissions, every DeepL API key behaved like an unrestricted key.
 
 **How scopes work**
 

--- a/docs/resources/roadmap-and-release-notes.mdx
+++ b/docs/resources/roadmap-and-release-notes.mdx
@@ -10,6 +10,11 @@ rss: true
 </Update>
 
 <Update label="June 2026">
+## June 23 - API Key Permissions General Availability
+- [API key permissions](/docs/getting-started/managing-api-keys#api-key-permissions) are now generally available. Scope a developer API key to specific endpoints so it can perform only the operations you allow.
+- Available on the API Pro, API Developer, API Growth, and API Enterprise plans.
+- Assign scopes when [creating or editing a key](https://www.deepl.com/your-account/keys). A scoped key returns `403 Forbidden` on any endpoint its scopes don't cover.
+
 ## June 17 - `latency_optimized` Now Supported for All Features
 - The `latency_optimized` model type is now fully compatible with all Translate API features, including:
   - [Tag handling v2](/docs/xml-and-html-handling/tag-handling-v2) (`tag_handling_version=v2`)


### PR DESCRIPTION
Prepares the docs for the **API key permissions GA launch on June 24**.

## Changes
- **Remove the private-beta callout** from the API key permissions section in [Managing API keys](/docs/getting-started/managing-api-keys#api-key-permissions) — the feature is now GA.
- **Note plan availability** in the section: API Pro, API Developer, API Growth, and API Enterprise.
- **Add a changelog entry** (`June 23 - API Key Permissions General Availability`) covering what the feature does, the plans with access, and the scope/`403` mechanics.

## Notes
- Branched fresh off `main` (PR #361, which added the section, is already merged).
- The historical `June 15 - API Key Permissions (Private Beta)` changelog entry is intentionally left in place.
- Ran through the editorial-reviewer agent; plan-name terminology ("API Pro" + the SKU family) confirmed.