### PR TITLE
docs: document tag_handling_version in translate response

### DIFF
--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -984,6 +984,15 @@
                             "description": "Indicates the translation model used. Only present if model_type parameter is included in the request.",
                             "type": "string",
                             "example": "quality_optimized"
+                          },
+                          "tag_handling_version": {
+                            "description": "The version of the tag handling algorithm used for the translation. Only present when the `tag_handling` parameter (`xml` or `html`) is set. If you don't specify `tag_handling_version`, this shows the default that was applied.",
+                            "type": "string",
+                            "enum": [
+                              "v2",
+                              "v1"
+                            ],
+                            "example": "v2"
                           }
                         }
                       }

--- a/api-reference/openapi.yaml
+++ b/api-reference/openapi.yaml
@@ -745,6 +745,16 @@ paths:
                             is included in the request.
                           type: string
                           example: quality_optimized
+                        tag_handling_version:
+                          description: The version of the tag handling algorithm used for the translation.
+                            Only present when the `tag_handling` parameter (`xml` or `html`) is set.
+                            If you don't specify `tag_handling_version`, this shows the default
+                            that was applied.
+                          type: string
+                          enum:
+                            - v2
+                            - v1
+                          example: v2
 
         400:
           $ref: '#/components/responses/BadRequest'

--- a/api-reference/translate.mdx
+++ b/api-reference/translate.mdx
@@ -326,7 +326,7 @@ Note that we do not include examples for our client libraries in every single se
     <li><code>v2</code>: Use the improved v2 algorithm.</li>
     <li><code>v1</code>: Use the previous v1 algorithm.</li>
   </ul>
-  When `tag_handling` is set, the response includes a `tag_handling_version` field showing which version is used, including the default applied when you don't specify `tag_handling_version`.
+  When `tag_handling` is set, the response includes a `tag_handling_version` field showing which version was applied, including the default when you don't specify one.
 </ParamField>
 <ParamField body="outline_detection" type="boolean">
   The automatic detection of the XML structure won't yield best results in all XML files. You can disable this automatic mechanism altogether by setting the <code>outline_detection</code> parameter to <code>false</code> and selecting the tags that should be considered structure tags. This will split sentences using the <code>splitting_tags</code> parameter.

--- a/api-reference/translate.mdx
+++ b/api-reference/translate.mdx
@@ -326,6 +326,7 @@ Note that we do not include examples for our client libraries in every single se
     <li><code>v2</code>: Use the improved v2 algorithm.</li>
     <li><code>v1</code>: Use the previous v1 algorithm.</li>
   </ul>
+  When `tag_handling` is set, the response includes a `tag_handling_version` field showing which version is used, including the default applied when you don't specify `tag_handling_version`.
 </ParamField>
 <ParamField body="outline_detection" type="boolean">
   The automatic detection of the XML structure won't yield best results in all XML files. You can disable this automatic mechanism altogether by setting the <code>outline_detection</code> parameter to <code>false</code> and selecting the tags that should be considered structure tags. This will split sentences using the <code>splitting_tags</code> parameter.


### PR DESCRIPTION
The `/v2/translate` response includes a `tag_handling_version` field when `tag_handling` is set, but it wasn't documented. This adds the field to the OpenAPI spec (YAML source; the JSON is regenerated by CI) and notes it on the Translate reference page.
