### PR TITLE
Add free signup note to estimation guide

### DIFF
--- a/docs/best-practices/estimating-character-usage.mdx
+++ b/docs/best-practices/estimating-character-usage.mdx
@@ -140,7 +140,7 @@ If you're translating the same content into multiple languages, each language co
 
 ## Validate your estimate
 
-Once you've estimated locally, validate with a small sample using the [`show_billed_characters`](/api-reference/translate#request-body-descriptions) parameter. This adds a `billed_characters` field to the API response so you can compare actual billed characters against your local count.
+Once you've estimated your characters, you can [sign up for a DeepL API plan for free](https://www.deepl.com/en/pro#api) and test a small sample against the live API. Use the [`show_billed_characters`](/api-reference/translate#request-body-descriptions) parameter to compare actual billed characters against your local count.
 
 ```bash
 curl -X POST https://api.deepl.com/v2/translate \


### PR DESCRIPTION
## Summary

- Clarifies that the "Validate your estimate" section requires a DeepL API account
- Adds a natural call-to-action linking to the free signup page before the API example

## Test plan

- [ ] Verify the link to `https://www.deepl.com/en/pro#api` renders correctly
- [ ] Verify the page still reads naturally at `/docs/best-practices/estimating-character-usage`

🤖 Generated with [Claude Code](https://claude.com/claude-code)