### PR TITLE
spec: add speech-to-speech to GET /v2/usage

### DIFF
--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -8,7 +8,7 @@
       "name": "DeepL - Contact us",
       "url": "https://www.deepl.com/contact-us"
     },
-    "version": "3.11.0"
+    "version": "3.12.0"
   },
   "externalDocs": {
     "description": "DeepL Pro - Plans and pricing",
@@ -3020,6 +3020,14 @@
                           "account_unit_count": 30,
                           "api_key_character_count": 0,
                           "character_count": 0
+                        },
+                        {
+                          "product_type": "speechToSpeech",
+                          "billing_unit": "minutes",
+                          "api_key_unit_count": 12,
+                          "account_unit_count": 12,
+                          "api_key_character_count": 0,
+                          "character_count": 0
                         }
                       ],
                       "api_key_character_count": 636,
@@ -3028,6 +3036,8 @@
                       "speech_to_text_milliseconds_limit": 0,
                       "speech_to_text_minutes_count": 30,
                       "speech_to_text_minutes_limit": 600,
+                      "speech_to_speech_minutes_count": 12,
+                      "speech_to_speech_minutes_limit": 600,
                       "start_time": "2025-05-13T09:18:42Z",
                       "end_time": "2025-06-13T09:18:42Z"
                     }
@@ -7983,6 +7993,16 @@
           "speech_to_text_minutes_limit": {
             "type": "integer",
             "description": "Only present for API Pro users. Maximum minutes of speech-to-text that can be used in the current billing period.",
+            "example": 600
+          },
+          "speech_to_speech_minutes_count": {
+            "type": "integer",
+            "description": "Only present for API Pro users. Minutes of speech-to-speech used in the current period. Milliseconds are rounded up to the nearest minute.",
+            "example": 12
+          },
+          "speech_to_speech_minutes_limit": {
+            "type": "integer",
+            "description": "Only present for API Pro users. Maximum minutes of speech-to-speech that can be used in the current billing period.",
             "example": 600
           },
           "start_time": {

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -8,7 +8,7 @@
       "name": "DeepL - Contact us",
       "url": "https://www.deepl.com/contact-us"
     },
-    "version": "3.10.0"
+    "version": "3.11.0"
   },
   "externalDocs": {
     "description": "DeepL Pro - Plans and pricing",
@@ -3014,18 +3014,20 @@
                           "character_count": 5941580
                         },
                         {
-                          "product_type": "speech_to_text",
-                          "billing_unit": "milliseconds",
-                          "api_key_unit_count": 1800000,
-                          "account_unit_count": 1800000,
+                          "product_type": "speechToText",
+                          "billing_unit": "minutes",
+                          "api_key_unit_count": 30,
+                          "account_unit_count": 30,
                           "api_key_character_count": 0,
                           "character_count": 0
                         }
                       ],
                       "api_key_character_count": 636,
                       "api_key_character_limit": 1000000000000,
-                      "speech_to_text_milliseconds_count": 1800000,
-                      "speech_to_text_milliseconds_limit": 36000000,
+                      "speech_to_text_milliseconds_count": 0,
+                      "speech_to_text_milliseconds_limit": 0,
+                      "speech_to_text_minutes_count": 30,
+                      "speech_to_text_minutes_limit": 600,
                       "start_time": "2025-05-13T09:18:42Z",
                       "end_time": "2025-06-13T09:18:42Z"
                     }
@@ -7921,7 +7923,7 @@
                   "type": "string",
                   "enum": [
                     "characters",
-                    "milliseconds"
+                    "minutes"
                   ],
                   "description": "The billing unit for this product type.",
                   "example": "characters"
@@ -7963,13 +7965,25 @@
           },
           "speech_to_text_milliseconds_count": {
             "type": "integer",
-            "description": "Only present for API Pro users. Milliseconds of speech-to-text used in the current period.",
-            "example": 1800000
+            "deprecated": true,
+            "description": "Deprecated. Always returns 0. Use speech_to_text_minutes_count instead.",
+            "example": 0
           },
           "speech_to_text_milliseconds_limit": {
             "type": "integer",
-            "description": "Only present for API Pro users. Milliseconds of speech-to-text limit in the current period.",
-            "example": 36000000
+            "deprecated": true,
+            "description": "Deprecated. Always returns 0. Use speech_to_text_minutes_limit instead.",
+            "example": 0
+          },
+          "speech_to_text_minutes_count": {
+            "type": "integer",
+            "description": "Only present for API Pro users. Minutes of speech-to-text used in the current period. Milliseconds are rounded up to the nearest minute.",
+            "example": 30
+          },
+          "speech_to_text_minutes_limit": {
+            "type": "integer",
+            "description": "Only present for API Pro users. Maximum minutes of speech-to-text that can be used in the current billing period.",
+            "example": 600
           },
           "start_time": {
             "type": "string",

--- a/api-reference/openapi.yaml
+++ b/api-reference/openapi.yaml
@@ -9,7 +9,7 @@ info:
   contact:
     name: DeepL - Contact us
     url: https://www.deepl.com/contact-us
-  version: 3.10.0
+  version: 3.11.0
 externalDocs:
   description: DeepL Pro - Plans and pricing
   url: https://www.deepl.com/pro#developer
@@ -2146,16 +2146,18 @@ paths:
                         account_unit_count: 5941580
                         api_key_character_count: 636
                         character_count: 5941580
-                      - product_type: speech_to_text
-                        billing_unit: milliseconds
-                        api_key_unit_count: 1800000
-                        account_unit_count: 1800000
+                      - product_type: speechToText
+                        billing_unit: minutes
+                        api_key_unit_count: 30
+                        account_unit_count: 30
                         api_key_character_count: 0
                         character_count: 0
                     api_key_character_count: 636
                     api_key_character_limit: 1000000000000
-                    speech_to_text_milliseconds_count: 1800000
-                    speech_to_text_milliseconds_limit: 36000000
+                    speech_to_text_milliseconds_count: 0
+                    speech_to_text_milliseconds_limit: 0
+                    speech_to_text_minutes_count: 30
+                    speech_to_text_minutes_limit: 600
                     start_time: '2025-05-13T09:18:42Z'
                     end_time: '2025-06-13T09:18:42Z'
         400:
@@ -5766,7 +5768,7 @@ components:
                 type: string
                 enum:
                   - characters
-                  - milliseconds
+                  - minutes
                 description: The billing unit for this product type.
                 example: characters
               api_key_unit_count:
@@ -5797,12 +5799,22 @@ components:
           example: 1000000000000
         speech_to_text_milliseconds_count:
           type: integer
-          description: Only present for API Pro users. Milliseconds of speech-to-text used in the current period.
-          example: 1800000
+          deprecated: true
+          description: Deprecated. Always returns 0. Use speech_to_text_minutes_count instead.
+          example: 0
         speech_to_text_milliseconds_limit:
           type: integer
-          description: Only present for API Pro users. Milliseconds of speech-to-text limit in the current period.
-          example: 36000000
+          deprecated: true
+          description: Deprecated. Always returns 0. Use speech_to_text_minutes_limit instead.
+          example: 0
+        speech_to_text_minutes_count:
+          type: integer
+          description: Only present for API Pro users. Minutes of speech-to-text used in the current period. Milliseconds are rounded up to the nearest minute.
+          example: 30
+        speech_to_text_minutes_limit:
+          type: integer
+          description: Only present for API Pro users. Maximum minutes of speech-to-text that can be used in the current billing period.
+          example: 600
         start_time:
           type: string
           format: date-time

--- a/api-reference/openapi.yaml
+++ b/api-reference/openapi.yaml
@@ -9,7 +9,7 @@ info:
   contact:
     name: DeepL - Contact us
     url: https://www.deepl.com/contact-us
-  version: 3.11.0
+  version: 3.12.0
 externalDocs:
   description: DeepL Pro - Plans and pricing
   url: https://www.deepl.com/pro#developer
@@ -2152,12 +2152,20 @@ paths:
                         account_unit_count: 30
                         api_key_character_count: 0
                         character_count: 0
+                      - product_type: speechToSpeech
+                        billing_unit: minutes
+                        api_key_unit_count: 12
+                        account_unit_count: 12
+                        api_key_character_count: 0
+                        character_count: 0
                     api_key_character_count: 636
                     api_key_character_limit: 1000000000000
                     speech_to_text_milliseconds_count: 0
                     speech_to_text_milliseconds_limit: 0
                     speech_to_text_minutes_count: 30
                     speech_to_text_minutes_limit: 600
+                    speech_to_speech_minutes_count: 12
+                    speech_to_speech_minutes_limit: 600
                     start_time: '2025-05-13T09:18:42Z'
                     end_time: '2025-06-13T09:18:42Z'
         400:
@@ -5814,6 +5822,14 @@ components:
         speech_to_text_minutes_limit:
           type: integer
           description: Only present for API Pro users. Maximum minutes of speech-to-text that can be used in the current billing period.
+          example: 600
+        speech_to_speech_minutes_count:
+          type: integer
+          description: Only present for API Pro users. Minutes of speech-to-speech used in the current period. Milliseconds are rounded up to the nearest minute.
+          example: 12
+        speech_to_speech_minutes_limit:
+          type: integer
+          description: Only present for API Pro users. Maximum minutes of speech-to-speech that can be used in the current billing period.
           example: 600
         start_time:
           type: string


### PR DESCRIPTION
## What
Adds speech-to-speech (STS) to `GET /v2/usage`:
- `speechToSpeech` product in `products[]` (`billing_unit: minutes`)
- top-level `speech_to_speech_minutes_count` / `speech_to_speech_minutes_limit`

## Stacked on #381
Built on top of #381 (the STT/minutes cleanup: `billing_unit` enum incl. removing the never-used `milliseconds` value, `speech_to_text_minutes_*`, deprecating the always-0 `speech_to_text_milliseconds_*`, and `product_type` casing). **Merge #381 first** — this PR's diff reduces to just the STS additions once #381 lands on main.
