### PR TITLE
docs: pipeline-generated pages (Voice)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -151,6 +151,70 @@
         ]
       },
       {
+<<<<<<< Updated upstream
+=======
+        "tab": "Translate",
+        "groups": [
+          {
+            "group": "Text Translation",
+            "pages": [
+              "docs/learning-how-tos/examples-and-guides/translation-beginners-guide",
+              "docs/learning-how-tos/examples-and-guides/how-to-use-context-parameter",
+              "docs/learning-how-tos/examples-and-guides/how-to-use-custom-reporting-tags",
+              "docs/learning-how-tos/examples-and-guides/translating-between-variants",
+              "docs/learning-how-tos/examples-and-guides/customizations-for-variants",
+              "docs/learning-how-tos/examples-and-guides/placeholder-tags",
+              "docs/best-practices/language-detection"
+            ]
+          },
+          {
+            "group": "Document Translation",
+            "pages": [
+              "docs/best-practices/document-translations"
+            ]
+          },
+          {
+            "group": "XML & HTML",
+            "pages": [
+              "docs/xml-and-html-handling/xml",
+              "docs/xml-and-html-handling/structured-content",
+              "docs/xml-and-html-handling/html",
+              "docs/xml-and-html-handling/customized-xml-outline-detection",
+              "docs/xml-and-html-handling/tag-handling-v2"
+            ]
+          },
+          {
+            "group": "Customize",
+            "pages": [
+              "docs/learning-how-tos/examples-and-guides/glossaries-in-the-real-world",
+              "docs/best-practices/custom-instructions",
+              "docs/learning-how-tos/examples-and-guides/how-to-use-translation-memories"
+            ]
+          }
+        ]
+      },
+      {
+        "tab": "Voice",
+        "pages": [
+          "api-reference/voice",
+          "docs/voice/stream-real-time-voice-translation",
+          "docs/voice/translate-an-audio-file"
+        ]
+      },
+      {
+        "tab": "Admin",
+        "pages": [
+          "docs/getting-started/managing-api-keys",
+          "docs/retrieving-usage-data",
+          "api-reference/admin-api",
+          "api-reference/admin-api/managing-admin-keys",
+          "api-reference/admin-api/managing-developer-keys",
+          "api-reference/usage-and-quota",
+          "api-reference/admin-api/organization-usage-analytics"
+        ]
+      },
+      {
+>>>>>>> Stashed changes
         "tab": "API Reference",
         "groups": [
           {
@@ -345,8 +409,14 @@
       {
         "title": "Resources",
         "items": [
-          { "label": "API Status", "href": "https://api-status.deepl.com" },
-          { "label": "DeepL Status", "href": "https://www.deeplstatus.com" }
+          {
+            "label": "API Status",
+            "href": "https://api-status.deepl.com"
+          },
+          {
+            "label": "DeepL Status",
+            "href": "https://www.deeplstatus.com"
+          }
         ]
       }
     ],
@@ -359,7 +429,9 @@
   },
   "api": {
     "examples": {
-      "languages": ["curl"],
+      "languages": [
+        "curl"
+      ],
       "defaults": "required"
     },
     "playground": {

--- a/docs.json
+++ b/docs.json
@@ -95,6 +95,13 @@
             ]
           },
           {
+            "group": "Voice",
+            "pages": [
+              "docs/voice/stream-real-time-voice-translation",
+              "docs/voice/translate-an-audio-file"
+            ]
+          },
+          {
             "group": "Going to Production",
             "pages": [
               "docs/getting-started/regional-endpoints",
@@ -151,70 +158,6 @@
         ]
       },
       {
-<<<<<<< Updated upstream
-=======
-        "tab": "Translate",
-        "groups": [
-          {
-            "group": "Text Translation",
-            "pages": [
-              "docs/learning-how-tos/examples-and-guides/translation-beginners-guide",
-              "docs/learning-how-tos/examples-and-guides/how-to-use-context-parameter",
-              "docs/learning-how-tos/examples-and-guides/how-to-use-custom-reporting-tags",
-              "docs/learning-how-tos/examples-and-guides/translating-between-variants",
-              "docs/learning-how-tos/examples-and-guides/customizations-for-variants",
-              "docs/learning-how-tos/examples-and-guides/placeholder-tags",
-              "docs/best-practices/language-detection"
-            ]
-          },
-          {
-            "group": "Document Translation",
-            "pages": [
-              "docs/best-practices/document-translations"
-            ]
-          },
-          {
-            "group": "XML & HTML",
-            "pages": [
-              "docs/xml-and-html-handling/xml",
-              "docs/xml-and-html-handling/structured-content",
-              "docs/xml-and-html-handling/html",
-              "docs/xml-and-html-handling/customized-xml-outline-detection",
-              "docs/xml-and-html-handling/tag-handling-v2"
-            ]
-          },
-          {
-            "group": "Customize",
-            "pages": [
-              "docs/learning-how-tos/examples-and-guides/glossaries-in-the-real-world",
-              "docs/best-practices/custom-instructions",
-              "docs/learning-how-tos/examples-and-guides/how-to-use-translation-memories"
-            ]
-          }
-        ]
-      },
-      {
-        "tab": "Voice",
-        "pages": [
-          "api-reference/voice",
-          "docs/voice/stream-real-time-voice-translation",
-          "docs/voice/translate-an-audio-file"
-        ]
-      },
-      {
-        "tab": "Admin",
-        "pages": [
-          "docs/getting-started/managing-api-keys",
-          "docs/retrieving-usage-data",
-          "api-reference/admin-api",
-          "api-reference/admin-api/managing-admin-keys",
-          "api-reference/admin-api/managing-developer-keys",
-          "api-reference/usage-and-quota",
-          "api-reference/admin-api/organization-usage-analytics"
-        ]
-      },
-      {
->>>>>>> Stashed changes
         "tab": "API Reference",
         "groups": [
           {

--- a/docs/voice/stream-real-time-voice-translation.mdx
+++ b/docs/voice/stream-real-time-voice-translation.mdx
@@ -1,0 +1,235 @@
+---
+title: "Stream Real-Time Voice Translation"
+description: "Learn how to open a WebSocket session to transcribe and translate live audio into multiple languages using the DeepL Voice API."
+covers: [Voice]
+---
+
+Real-time voice translation lets you stream live audio to DeepL and receive transcriptions and translations as the speaker talks. This guide walks you through the full flow: creating a session, connecting via WebSocket, and handling reconnections if the connection drops.
+
+## Prerequisites
+
+- A DeepL API Pro account with Voice API access
+- An audio source you can encode as Opus (in an Ogg or WebM container) or raw PCM
+- A WebSocket client library in your language of choice
+
+## Step 1: Create a session
+
+The API uses a two-step flow: create a session via POST to get a WebSocket URL and token, then stream audio over that WebSocket. If the connection drops, you can request a new URL using the token from the last successful message, without losing session state.
+
+Send a POST request with your audio format and target languages. The only required field is `source_media_content_type`.
+
+```bash
+curl -X POST https://api.deepl.com/v3/voice/realtime \
+  -H "Authorization: DeepL-Auth-Key YOUR_AUTH_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "source_media_content_type": "audio/ogg; codecs=opus",
+    "source_language": "en",
+    "source_language_mode": "auto",
+    "target_languages": ["de", "fr", "es"],
+    "message_format": "json"
+  }'
+```
+
+A successful response looks like this:
+
+```json
+{
+  "session_id": "4f911080-cfe2-41d4-8269-0e6ec15a0354",
+  "streaming_url": "wss://api.deepl.com/v3/voice/realtime/connect",
+  "token": "VGhpcyBpcyBhIGZha2UgdG9rZW4K"
+}
+```
+
+Save all three values. You'll use `streaming_url` to connect and `token` to reconnect if the session drops.
+
+If you know the speaker's language in advance, set `source_language_mode` to `fixed` — this skips language detection and reduces latency. Leave it as `auto` (the default) when the language may vary.
+
+See the [POST /v3/voice/realtime reference](/api-reference/voice/realtime-session) for the full list of request parameters.
+
+## Step 2: Connect via WebSocket
+
+Open a WebSocket connection to the `streaming_url` from the session response. Include the token as a query parameter:
+
+```text
+wss://api.deepl.com/v3/voice/realtime/connect?token=VGhpcyBpcyBhIGZha2UgdG9rZW4K
+```
+
+The following example shows how to open the connection, send a binary audio frame, and read a message:
+
+```python
+import asyncio
+import websockets
+
+async def connect_and_stream(streaming_url: str, token: str, audio_frame: bytes):
+    url_with_token = f"{streaming_url}?token={token}"
+    async with websockets.connect(url_with_token) as ws:
+        # Send a binary audio frame
+        await ws.send(audio_frame)
+        # Read the next message from the server
+        message = await ws.recv()
+        print(message)
+```
+
+Once connected, begin sending audio frames as binary messages. The API returns transcript and translation messages as text frames on the same connection.
+
+<Tip>
+Update your saved token each time you receive a new one in a message from the server. The token rotates during a session and you'll need the latest one to reconnect.
+</Tip>
+
+See the [WebSocket Streaming reference](/api-reference/voice/websocket-streaming) for the full message schema, including interim vs. final transcript events.
+
+## Step 3: Handle reconnections
+
+Networks drop. The API gives you a way to resume a session without starting over.
+
+If your WebSocket connection closes unexpectedly, call `GET /v3/voice/realtime` with the most recent token you received:
+
+```bash
+curl "https://api.deepl.com/v3/voice/realtime?token=VGhpcyBpcyBhIGZha2UgdG9rZW4K" \
+  -H "Authorization: DeepL-Auth-Key YOUR_AUTH_KEY"
+```
+
+The response has the same shape as the session creation response:
+
+```json
+{
+  "session_id": "4f911080-cfe2-41d4-8269-0e6ec15a0354",
+  "streaming_url": "wss://api.deepl.com/v3/voice/realtime/connect",
+  "token": "VGhpcyBpcyBhIGZha2UgdG9rZW4K"
+}
+```
+
+Error response (expired token):
+
+```json
+{
+  "message": "Invalid token"
+}
+```
+
+Use the new `streaming_url` and `token` to reconnect exactly as you did in Step 2.
+
+<Warning>
+Always use the latest token received from the server. Using a stale or expired token returns a 401 and the session cannot be resumed.
+</Warning>
+
+To recover, call `POST /v3/voice/realtime` to start a new session.
+
+## Complete example
+
+This Python example shows the full flow: create a session, stream audio from a file, and reconnect on disconnect.
+
+```python
+import asyncio
+import json
+import aiohttp
+import websockets
+
+# This example streams audio from a local Ogg/Opus file.
+# Install dependencies: pip install aiohttp websockets
+# Usage: place your audio file at the path set in AUDIO_FILE_PATH, then run:
+#   python voice_translation.py
+
+AUTH_KEY = "YOUR_AUTH_KEY"
+SESSION_ENDPOINT = "https://api.deepl.com/v3/voice/realtime"
+AUDIO_FILE_PATH = "audio.ogg"  # Path to a local Ogg/Opus audio file
+CHUNK_SIZE = 4096  # Bytes per audio frame sent to the API
+
+
+async def file_audio_source(path: str):
+    """Async generator that yields chunks of a local audio file."""
+    with open(path, "rb") as f:
+        while True:
+            chunk = f.read(CHUNK_SIZE)
+            if not chunk:
+                break
+            yield chunk
+            await asyncio.sleep(0)  # Yield control to the event loop
+
+
+async def create_session() -> dict:
+    """Request a streaming URL and initial token from the Voice API."""
+    async with aiohttp.ClientSession() as http:
+        async with http.post(
+            SESSION_ENDPOINT,
+            headers={"Authorization": f"DeepL-Auth-Key {AUTH_KEY}"},
+            json={
+                "source_media_content_type": "audio/ogg; codecs=opus",
+                "source_language": "en",
+                "source_language_mode": "fixed",
+                "target_languages": ["de", "fr"],
+                "message_format": "json",
+            },
+        ) as resp:
+            resp.raise_for_status()
+            return await resp.json()
+
+
+async def reconnect(token: str) -> dict:
+    """Obtain a fresh streaming URL using the last known token."""
+    async with aiohttp.ClientSession() as http:
+        async with http.get(
+            SESSION_ENDPOINT,
+            headers={"Authorization": f"DeepL-Auth-Key {AUTH_KEY}"},
+            params={"token": token},
+        ) as resp:
+            resp.raise_for_status()
+            return await resp.json()
+
+
+async def stream_audio(streaming_url: str, token: str, audio_source) -> str:
+    """
+    Stream audio frames and print incoming transcripts.
+    Returns the latest token for reconnection use.
+    """
+    latest_token = token
+    url_with_token = f"{streaming_url}?token={token}"
+
+    async with websockets.connect(url_with_token) as ws:
+        async def send_audio():
+            async for frame in audio_source:
+                await ws.send(frame)
+            await ws.close()
+
+        async def receive_messages():
+            nonlocal latest_token
+            async for message in ws:
+                data = json.loads(message)
+                # Rotate the token whenever the server sends a new one
+                if "token" in data:
+                    latest_token = data["token"]
+                if data.get("type") == "transcript":
+                    print(f"[{data['language']}] {data['text']}")
+
+        await asyncio.gather(send_audio(), receive_messages())
+
+    return latest_token
+
+
+async def main():
+    session = await create_session()
+    token = session["token"]
+    url = session["streaming_url"]
+
+    while True:
+        # Re-open the file on each reconnect attempt; the generator is exhausted after each stream_audio call.
+        audio_source = file_audio_source(AUDIO_FILE_PATH)
+        try:
+            token = await stream_audio(url, token, audio_source)
+            break  # Clean close — we're done
+        except websockets.exceptions.ConnectionClosed:
+            print("Connection dropped, reconnecting...")
+            session = await reconnect(token)
+            token = session["token"]
+            url = session["streaming_url"]
+
+
+asyncio.run(main())
+```
+
+## Next steps
+
+- See the [WebSocket Streaming reference](/api-reference/voice/websocket-streaming) for the complete message schema and all event types.
+- To translate pre-recorded audio files instead of live streams, see [Translate Audio Files](/api-reference/jobs-voice-translate).
+- To apply a custom glossary to your translations, see the [Glossaries documentation](/docs/api/glossaries).

--- a/docs/voice/translate-an-audio-file.mdx
+++ b/docs/voice/translate-an-audio-file.mdx
@@ -1,0 +1,149 @@
+---
+title: "Translate an Audio File"
+description: "Submit a pre-recorded audio file for translation and download the results using the async Voice Translate Job API."
+covers: [Translate Audio Files]
+---
+
+<Warning>
+  **Closed alpha.** This API may change without notice and is only available to select DeepL customers. See [alpha and beta features](/docs/resources/alpha-and-beta-features) for details. To request access, contact your customer success manager.
+</Warning>
+
+The Voice Translate Job API translates pre-recorded audio files asynchronously. Because translation happens in the background, the workflow has three distinct phases: create a job and upload your file, poll until results are ready, then download them. This guide walks you through each phase with a concrete example.
+
+For a live audio stream, use the [real-time Voice API](/api-reference/voice) instead.
+
+## Prerequisites
+
+- A DeepL API Pro account with access to the closed-alpha Voice Translate Job API
+- Your API authentication key
+- A pre-recorded audio file (see the [Reference](/api-reference/jobs-voice-translate/reference#supported-source-audio-formats) for supported formats and limits)
+
+## Step 1: Create a job
+
+Send a `POST /v1/jobs/voice/translate` request describing your source file and the outputs you want. The response returns a pre-signed `upload_url` for the source audio.
+
+This example translates an English podcast episode into German plain text and Spanish PCM audio:
+
+```bash
+curl -X POST https://api.deepl.com/v1/jobs/voice/translate \
+  -H "Authorization: DeepL-Auth-Key YOUR_AUTH_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "source_file": {
+      "name": "podcast-episode-42.mp3",
+      "content_type": "audio/mpeg",
+      "content_length": 15728640
+    },
+    "parameters": {
+      "source_language": "en"
+    },
+    "targets": [
+      { "language": "de", "type": "text/plain" },
+      { "language": "es", "type": "audio/pcm;encoding=s16le;rate=16000" }
+    ]
+  }'
+```
+
+`content_length` must be the exact byte size of the file you will upload. The API uses this value to size the upload slot.
+
+Example response:
+
+```json
+{
+  "job_id": "a74d88fb-ed2a-4943-a664-a4512398b994",
+  "signature": "eyJhbGciOiJIUzI1NiIs...",
+  "upload_url": "https://assets.deepl.com/collections/a74d88fb-ed2a-4943-a664-a4512398b994/assets/b1c2d3e4-f5a6-7890-abcd-ef1234567890"
+}
+```
+
+Save the `job_id` — you need it to check status and download results.
+
+## Step 2: Upload your audio file
+
+PUT the file directly to the `upload_url` from the previous response. Set `Content-Type` to match the value you declared in the create request.
+
+```bash
+curl -X PUT "https://assets.deepl.com/collections/a74d88fb-ed2a-4943-a664-a4512398b994/assets/b1c2d3e4-f5a6-7890-abcd-ef1234567890" \
+  -H "Content-Type: audio/mpeg" \
+  --data-binary @podcast-episode-42.mp3
+```
+
+You have 5 minutes to upload the file after creating the job. If the upload window expires, the job is abandoned and you must create a new one.
+
+<Warning>
+  The upload URL is pre-signed and does not require your DeepL API key. Do not include an `Authorization` header in this request.
+</Warning>
+
+## Step 3: Poll for results
+
+Poll `GET /v1/jobs/voice/translate/{job_id}` until each target's status is `complete` or `failed`. Targets are processed independently, so some may finish before others.
+
+```bash
+curl https://api.deepl.com/v1/jobs/voice/translate/a74d88fb-ed2a-4943-a664-a4512398b994 \
+  -H "Authorization: DeepL-Auth-Key YOUR_AUTH_KEY"
+```
+
+While processing, the response looks like this:
+
+```json
+{
+  "job_id": "a74d88fb-ed2a-4943-a664-a4512398b994",
+  "operation": "translate",
+  "product": "voice",
+  "source_file": {
+    "name": "podcast-episode-42.mp3",
+    "content_type": "audio/mpeg",
+    "content_length": 15728640
+  },
+  "parameters": { "source_language": "en" },
+  "targets": [
+    { "language": "de", "type": "text/plain" },
+    { "language": "es", "type": "audio/pcm;encoding=s16le;rate=16000" }
+  ],
+  "results": [
+    { "status": "processing" },
+    { "status": "processing" }
+  ],
+  "created_at": "2026-10-01T01:03:03.444Z",
+  "updated_at": "2026-10-01T04:03:03.333Z"
+}
+```
+
+When at least one target completes, its result entry includes a `download_url`:
+
+```json
+{
+  "results": [
+    {
+      "status": "complete",
+      "download_url": "https://assets.deepl.com/collections/a74d88fb/assets/c3d4e5f6",
+      "signature": "eyJhbGciOiJIUzI1NiIs..."
+    },
+    {
+      "status": "failed",
+      "error": { "message": "processing failed" }
+    }
+  ]
+}
+```
+
+Results appear in the same order as the `targets` array in your create request. A `failed` result does not affect other targets — download any `complete` results regardless.
+
+Poll at a reasonable interval (every 10-30 seconds for short files, every 60 seconds for longer ones). Avoid polling faster than once every 5 seconds.
+
+## Step 4: Download results
+
+GET each `download_url` to retrieve the translated output. No authentication header is required.
+
+```bash
+curl -o translation-de.txt \
+  "https://assets.deepl.com/collections/a74d88fb/assets/c3d4e5f6"
+```
+
+Download results within 1 hour of upload. After all targets are downloaded (or the window expires), the job is deleted and the `job_id` returns `404`. Usage is billed based on the duration of the source audio.
+
+## Next steps
+
+- Check the [Reference](/api-reference/jobs-voice-translate/reference) for the full list of supported output formats, source audio formats, file size limits, and concurrent job limits
+- For the full request and response schemas, see the [Create Job](/api-reference/jobs-voice-translate/create-voice-translate-job) and [Get Job Status](/api-reference/jobs-voice-translate/get-voice-translate-job-status) endpoint references
+- To translate live audio instead of pre-recorded files, see the [real-time Voice API](/api-reference/voice)


### PR DESCRIPTION
## Summary
Generated documentation pages from the agentic docs pipeline (run `20260708-205254`).

Families: Voice
Model: claude-sonnet-4-6

### Pages added/updated
- `docs/voice/stream-real-time-voice-translation.mdx` — missing_group_coverage
- `docs/voice/translate-an-audio-file.mdx` — missing_group_coverage

### Quality checks
- Generation: all pages generated successfully

## How to review
1. Check out this branch and run `mint dev` to preview locally
2. Review each page for accuracy and tone
3. Verify navigation in docs.json makes sense

---
Generated by the agentic docs pipeline (`pipeline/generate.py`)