### PR TITLE
spec: align glossary, translation memory, and usage response schemas with the live API

### DIFF
--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -1752,6 +1752,9 @@
               }
             }
           },
+          "400": {
+            "$ref": "#/components/responses/BadRequestGlossaries"
+          },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
           },
@@ -1835,6 +1838,9 @@
                 }
               }
             }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequestGlossaries"
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
@@ -2086,7 +2092,16 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/GlossaryDictionary"
+                  "type": "object",
+                  "properties": {
+                    "dictionaries": {
+                      "description": "The dictionaries of the glossary, each with its entries in the requested format.",
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/MultilingualGlossaryEntries"
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -3783,6 +3798,9 @@
               }
             }
           },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
           },
@@ -3864,6 +3882,9 @@
                 }
               }
             }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
@@ -4040,6 +4061,9 @@
               }
             }
           },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
           },
@@ -4163,6 +4187,9 @@
                 "$ref": "#/components/headers/X-Trace-ID"
               }
             }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
@@ -4407,6 +4434,9 @@
               }
             }
           },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
           },
@@ -4560,6 +4590,9 @@
                 "$ref": "#/components/headers/X-Trace-ID"
               }
             }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
@@ -7403,6 +7436,14 @@
           },
           "entries_format": {
             "$ref": "#/components/schemas/GlossaryEntriesFormat"
+          },
+          "entry_count": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GlossaryEntryCount"
+              }
+            ],
+            "readOnly": true
           }
         }
       },
@@ -7744,6 +7785,18 @@
             "description": "The number of segments stored in the translation memory.",
             "type": "integer",
             "example": 34
+          },
+          "creation_time": {
+            "description": "The creation time of the translation memory in the ISO 8601-1:2019 format (e.g.: `2021-08-03T14:16:18.329Z`).",
+            "type": "string",
+            "format": "date-time",
+            "example": "2026-04-01T16:34:25.223Z"
+          },
+          "updated_time": {
+            "description": "The time of the last update to the translation memory in the ISO 8601-1:2019 format (e.g.: `2021-08-03T14:16:18.329Z`).",
+            "type": "string",
+            "format": "date-time",
+            "example": "2026-04-01T16:34:25.264Z"
           }
         }
       },
@@ -7917,6 +7970,26 @@
             "type": "integer",
             "format": "int64",
             "example": 1250000
+          },
+          "document_count": {
+            "description": "Documents translated so far in the current billing period. Only present for accounts with a document limit.",
+            "type": "integer",
+            "format": "int64"
+          },
+          "document_limit": {
+            "description": "Current maximum number of documents that can be translated per billing period. Only present for accounts with a document limit.",
+            "type": "integer",
+            "format": "int64"
+          },
+          "team_document_count": {
+            "description": "Documents translated by all users in the team so far in the current billing period. Only present for accounts with a team document limit.",
+            "type": "integer",
+            "format": "int64"
+          },
+          "team_document_limit": {
+            "description": "Current maximum number of documents that can be translated by the team per billing period. Only present for accounts with a team document limit.",
+            "type": "integer",
+            "format": "int64"
           },
           "products": {
             "type": "array",

--- a/api-reference/openapi.yaml
+++ b/api-reference/openapi.yaml
@@ -1337,6 +1337,8 @@ paths:
                         target_lang: EN
                         entry_count: 2
                     creation_time: '2021-08-03T14:16:18.329Z'
+        400:
+          $ref: '#/components/responses/BadRequestGlossaries'
         401:
           $ref: '#/components/responses/Unauthorized'
         403:
@@ -1390,6 +1392,8 @@ paths:
                     target_lang: EN
                     entry_count: 2
                 creation_time: '2021-08-03T14:16:18.429Z'
+        400:
+          $ref: '#/components/responses/BadRequestGlossaries'
         401:
           $ref: '#/components/responses/Unauthorized'
         403:
@@ -1547,7 +1551,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GlossaryDictionary'
+                type: object
+                properties:
+                  dictionaries:
+                    description: The dictionaries of the glossary, each with its entries in the requested format.
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/MultilingualGlossaryEntries'
         400:
           $ref: '#/components/responses/BadRequestGlossaries'
         401:
@@ -2678,6 +2688,8 @@ paths:
                       - zh
                       segment_count: 23
                     total_count: 2
+        400:
+          $ref: '#/components/responses/BadRequest'
         401:
           $ref: '#/components/responses/Unauthorized'
         403:
@@ -2730,6 +2742,8 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/StyleRuleList'
+        400:
+          $ref: '#/components/responses/BadRequest'
         401:
           $ref: '#/components/responses/Unauthorized'
         403:
@@ -2843,6 +2857,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StyleRuleList'
+        400:
+          $ref: '#/components/responses/BadRequest'
         401:
           $ref: '#/components/responses/Unauthorized'
         403:
@@ -2920,6 +2936,8 @@ paths:
           headers:
             X-Trace-ID:
               $ref: '#/components/headers/X-Trace-ID'
+        400:
+          $ref: '#/components/responses/BadRequest'
         401:
           $ref: '#/components/responses/Unauthorized'
         403:
@@ -3074,6 +3092,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CustomInstruction'
+        400:
+          $ref: '#/components/responses/BadRequest'
         401:
           $ref: '#/components/responses/Unauthorized'
         403:
@@ -3173,6 +3193,8 @@ paths:
           headers:
             X-Trace-ID:
               $ref: '#/components/headers/X-Trace-ID'
+        400:
+          $ref: '#/components/responses/BadRequest'
         401:
           $ref: '#/components/responses/Unauthorized'
         403:
@@ -5296,6 +5318,10 @@ components:
           $ref: '#/components/schemas/GlossaryEntries'
         entries_format:
           $ref: '#/components/schemas/GlossaryEntriesFormat'
+        entry_count:
+          allOf:
+            - $ref: '#/components/schemas/GlossaryEntryCount'
+          readOnly: true
     GlossaryEntries:
       type: string
       description: The entries of the glossary. The entries have to be specified
@@ -5598,6 +5624,16 @@ components:
           description: The number of segments stored in the translation memory.
           type: integer
           example: 34
+        creation_time:
+          description: 'The creation time of the translation memory in the ISO 8601-1:2019 format (e.g.: `2021-08-03T14:16:18.329Z`).'
+          type: string
+          format: date-time
+          example: '2026-04-01T16:34:25.223Z'
+        updated_time:
+          description: 'The time of the last update to the translation memory in the ISO 8601-1:2019 format (e.g.: `2021-08-03T14:16:18.329Z`).'
+          type: string
+          format: date-time
+          example: '2026-04-01T16:34:25.264Z'
     TranslationMemoryId:
       type: string
       format: uuid
@@ -5772,6 +5808,22 @@ components:
           type: integer
           format: int64
           example: 1250000
+        document_count:
+          description: Documents translated so far in the current billing period. Only present for accounts with a document limit.
+          type: integer
+          format: int64
+        document_limit:
+          description: Current maximum number of documents that can be translated per billing period. Only present for accounts with a document limit.
+          type: integer
+          format: int64
+        team_document_count:
+          description: Documents translated by all users in the team so far in the current billing period. Only present for accounts with a team document limit.
+          type: integer
+          format: int64
+        team_document_limit:
+          description: Current maximum number of documents that can be translated by the team per billing period. Only present for accounts with a team document limit.
+          type: integer
+          format: int64
         products:
           type: array
           description: Only present for API Pro users. Per-product usage details.


### PR DESCRIPTION
Comparing the spec against live API responses shows a few places where the declared schemas are slightly off from what the API returns. This PR aligns them. The spec still validates as OpenAPI 3.0.3; `openapi.json` regenerates via the workflow.

### 1. v3 glossary responses include `entry_count` per dictionary

`POST /v3/glossaries` (201), `GET`/`PATCH /v3/glossaries/{glossary_id}`, and the list endpoint all return:

```json
"dictionaries": [
  { "source_lang": "en", "target_lang": "de", "entry_count": 1 }
]
```

`GlossaryDictionary` didn't declare `entry_count`, even though the spec's own response examples already include it. Added as `readOnly` (the same schema is used in create/patch request bodies, where it isn't sent). The v2 glossary schema already documents this field.

### 2. `GET /v3/glossaries/{glossary_id}/entries` returns a wrapper object

The spec declared the 200 response is a `GlossaryDictionary`. The actual response:

```json
{
  "dictionaries": [
    { "source_lang": "en", "target_lang": "de", "entries": "hello\tHallo", "entries_format": "tsv" }
  ]
}
```

Now declared as an object with a `dictionaries` array of `MultilingualGlossaryEntries` (this endpoint does not return `entry_count`).

### 3. Translation memories include timestamps

Every item in `GET /v3/translation_memories` returns `creation_time` and `updated_time` (ISO 8601), neither declared:

```json
{ "translation_memory_id": "…", "name": "…", "source_language": "en",
  "target_languages": ["de"], "segment_count": 1,
  "creation_time": "2026-04-01T16:34:25.223Z", "updated_time": "2026-04-01T16:34:25.264Z" }
```

Added as optional `date-time` fields.

### 4. `GET /v2/usage` document quota fields

Keys belonging to CAT-tool (non-API) subscriptions return the document quota fields, and only those (no character fields):

```json
{ "team_document_count": 0, "document_count": 0, "team_document_limit": 20, "document_limit": 20 }
```

None of the four were declared; added as optional integers alongside the existing character fields.

### 5. The v3 read/delete operations can return 400

Eight operations declared 401 and up but not 400. Five are id-based reads/deletes where the API demonstrably returns 400 on a malformed id (`GET /v3/glossaries/{id}`, `GET`/`DELETE /v3/style_rules/{id}`, `GET`/`DELETE /v3/style_rules/{id}/custom_instructions/{id}`):

```
GET /v3/glossaries/not-a-uuid
→ 400 { "message": "Bad request. Reason: Invalid or missing glossary id" }
```

The other three are the list endpoints (`GET /v3/glossaries`, `GET /v3/translation_memories`, `GET /v3/style_rules`), where a 400 wasn't reproducible with malformed query parameters; they are declared for consistency with the v2 equivalents (`GET /v2/glossaries`, `GET /v2/glossary-language-pairs`, `GET /v2/languages`), which all declare 400. Happy to drop those three if you'd rather only document reproduced behavior.

All use the existing `BadRequest` / `BadRequestGlossaries` response components.
