### PR TITLE
docs(document): add enable_watermark parameter to POST /v2/document

### DIFF
--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -1077,6 +1077,14 @@
                     "file": "@document.docx"
                   }
                 },
+                "Watermark": {
+                  "summary": "Adding a \"Translated by DeepL\" watermark",
+                  "value": {
+                    "target_lang": "DE",
+                    "file": "@document.docx",
+                    "enable_watermark": true
+                  }
+                },
                 "Glossary": {
                   "summary": "Using a Glossary",
                   "value": {
@@ -1168,6 +1176,11 @@
                   },
                   "translation_memory_threshold": {
                     "$ref": "#/components/schemas/TranslationMemoryThreshold"
+                  },
+                  "enable_watermark": {
+                    "description": "When `true`, adds a \"Translated by DeepL\" watermark to the translated document.\n\nOnly supported for `docx` and `pdf` output. For all other output formats the parameter is ignored and the document is returned without a watermark.",
+                    "type": "boolean",
+                    "default": false
                   },
                   "enable_beta_languages": {
                     "description": "This parameter is maintained for backward compatibility and has no effect.",

--- a/api-reference/openapi.yaml
+++ b/api-reference/openapi.yaml
@@ -827,6 +827,12 @@ paths:
                 value:
                   target_lang: DE
                   file: '@document.docx'
+              Watermark:
+                summary: Adding a "Translated by DeepL" watermark
+                value:
+                  target_lang: DE
+                  file: '@document.docx'
+                  enable_watermark: true
               Glossary:
                 summary: Using a Glossary
                 value:
@@ -925,6 +931,13 @@ paths:
                   $ref: '#/components/schemas/TranslationMemoryId'
                 translation_memory_threshold:
                   $ref: '#/components/schemas/TranslationMemoryThreshold'
+                enable_watermark:
+                  description: |-
+                    When `true`, adds a "Translated by DeepL" watermark to the translated document.
+
+                    Only supported for `docx` and `pdf` output. For all other output formats the parameter is ignored and the document is returned without a watermark.
+                  type: boolean
+                  default: false
                 enable_beta_languages:
                   description: |-
                     This parameter is maintained for backward compatibility and has no effect.


### PR DESCRIPTION
## What

Documents the `enable_watermark` request parameter on `POST /v2/document`, which is already live in the API but missing from the reference.

When set to `true`, a **"Translated by DeepL"** watermark is applied to the translated output document.

## Changes

- Add `enable_watermark` (boolean, default `false`) to the multipart request body of `POST /v2/document` in both `api-reference/openapi.yaml` (source) and `api-reference/openapi.json` (generated).
- Add a **Watermark** usage example alongside the existing Basic/Glossary examples.

## Notes

- The parameter is only honored for **`docx`** and **`pdf`** output; for other formats it is ignored and the document is returned without a watermark. This is stated in the parameter description.
- The `.mdx` page needs no change — it renders from the OpenAPI spec.
