### PR TITLE
docs(document): add enable_watermark parameter to POST /v2/document

### DIFF
--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -1078,10 +1078,10 @@
                   }
                 },
                 "Watermark": {
-                  "summary": "Adding a \"Translated by DeepL\" watermark",
+                  "summary": "Adding a \"Translated by DeepL\" watermark (docx/pdf only)",
                   "value": {
                     "target_lang": "DE",
-                    "file": "@document.docx",
+                    "file": "@document.pdf",
                     "enable_watermark": true
                   }
                 },

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -1077,6 +1077,14 @@
                     "file": "@document.docx"
                   }
                 },
+                "Watermark": {
+                  "summary": "Adding a \"Translated by DeepL\" watermark",
+                  "value": {
+                    "target_lang": "DE",
+                    "file": "@document.docx",
+                    "enable_watermark": true
+                  }
+                },
                 "Glossary": {
                   "summary": "Using a Glossary",
                   "value": {
@@ -1168,6 +1176,11 @@
                   },
                   "translation_memory_threshold": {
                     "$ref": "#/components/schemas/TranslationMemoryThreshold"
+                  },
+                  "enable_watermark": {
+                    "description": "When `true`, adds a \"Translated by DeepL\" watermark to the translated document.\n\nOnly supported for `docx` and `pdf` output. For all other output formats the parameter is ignored and the document is returned without a watermark.",
+                    "type": "boolean",
+                    "default": false
                   },
                   "enable_beta_languages": {
                     "description": "This parameter is maintained for backward compatibility and has no effect.",

--- a/api-reference/openapi.yaml
+++ b/api-reference/openapi.yaml
@@ -827,6 +827,12 @@ paths:
                 value:
                   target_lang: DE
                   file: '@document.docx'
+              Watermark:
+                summary: Adding a "Translated by DeepL" watermark
+                value:
+                  target_lang: DE
+                  file: '@document.docx'
+                  enable_watermark: true
               Glossary:
                 summary: Using a Glossary
                 value:
@@ -925,6 +931,13 @@ paths:
                   $ref: '#/components/schemas/TranslationMemoryId'
                 translation_memory_threshold:
                   $ref: '#/components/schemas/TranslationMemoryThreshold'
+                enable_watermark:
+                  description: |-
+                    When `true`, adds a "Translated by DeepL" watermark to the translated document.
+
+                    Only supported for `docx` and `pdf` output. For all other output formats the parameter is ignored and the document is returned without a watermark.
+                  type: boolean
+                  default: false
                 enable_beta_languages:
                   description: |-
                     This parameter is maintained for backward compatibility and has no effect.

--- a/api-reference/openapi.yaml
+++ b/api-reference/openapi.yaml
@@ -828,10 +828,10 @@ paths:
                   target_lang: DE
                   file: '@document.docx'
               Watermark:
-                summary: Adding a "Translated by DeepL" watermark
+                summary: Adding a "Translated by DeepL" watermark (docx/pdf only)
                 value:
                   target_lang: DE
-                  file: '@document.docx'
+                  file: '@document.pdf'
                   enable_watermark: true
               Glossary:
                 summary: Using a Glossary

--- a/docs/resources/roadmap-and-release-notes.mdx
+++ b/docs/resources/roadmap-and-release-notes.mdx
@@ -10,6 +10,11 @@ rss: true
 </Update>
 
 <Update label="July 2026">
+## July 14 - Watermarking for Document Translation
+- [`POST /v2/document`](/api-reference/document/upload-and-translate-a-document) now accepts an `enable_watermark` parameter. When set to `true`, a "Translated by DeepL" watermark is applied to the translated document.
+- Supported for `docx` and `pdf` output only; the parameter is ignored for all other formats.
+- See the [document translation](/api-reference/document#request-body-descriptions) overview page for parameter details.
+
 ## July 2 - New Voice API Languages: Hindi, Malay, and Tamil
 - The Voice API now supports `hi` (Hindi), `ms` (Malay), and `ta` (Tamil) in beta. Translation is provided by DeepL; transcription and translated speech are provided by external service partners.
 - These languages are marked `"external": true` in the [`GET /v3/languages?resource=voice`](/docs/languages/using-the-languages-api) response. Because they are beta and external, call with `include=beta&include=external` to see them.


### PR DESCRIPTION
## What

Documents the `enable_watermark` request parameter on `POST /v2/document`, which is already live in the API but missing from the reference.

When set to `true`, a **"Translated by DeepL"** watermark is applied to the translated output document.

## Changes

- Add `enable_watermark` (boolean, default `false`) to the multipart request body of `POST /v2/document` in `api-reference/openapi.yaml`.
- Add a **Watermark** usage example alongside the existing Basic/Glossary examples.
- `openapi.json` is regenerated from the YAML by the `Update OpenAPI JSON files from YAML sources` workflow.

## Notes

- The parameter is only honored for **`docx`** and **`pdf`** output; for other formats it is ignored and the document is returned without a watermark. This is stated in the parameter description.
- The `.mdx` page needs no change — it renders from the OpenAPI spec.
- Opened from a branch in this repo (not a fork) so the JSON-conversion workflow can run.
