### PR TITLE
Revert "docs(document): add enable_watermark parameter to POST /v2/document" (#399)

### DIFF
--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -1077,14 +1077,6 @@
                     "file": "@document.docx"
                   }
                 },
-                "Watermark": {
-                  "summary": "Adding a \"Translated by DeepL\" watermark (docx/pdf only)",
-                  "value": {
-                    "target_lang": "DE",
-                    "file": "@document.pdf",
-                    "enable_watermark": true
-                  }
-                },
                 "Glossary": {
                   "summary": "Using a Glossary",
                   "value": {
@@ -1176,11 +1168,6 @@
                   },
                   "translation_memory_threshold": {
                     "$ref": "#/components/schemas/TranslationMemoryThreshold"
-                  },
-                  "enable_watermark": {
-                    "description": "When `true`, adds a \"Translated by DeepL\" watermark to the translated document.\n\nOnly supported for `docx` and `pdf` output. For all other output formats the parameter is ignored and the document is returned without a watermark.",
-                    "type": "boolean",
-                    "default": false
                   },
                   "enable_beta_languages": {
                     "description": "This parameter is maintained for backward compatibility and has no effect.",

--- a/api-reference/openapi.yaml
+++ b/api-reference/openapi.yaml
@@ -827,12 +827,6 @@ paths:
                 value:
                   target_lang: DE
                   file: '@document.docx'
-              Watermark:
-                summary: Adding a "Translated by DeepL" watermark (docx/pdf only)
-                value:
-                  target_lang: DE
-                  file: '@document.pdf'
-                  enable_watermark: true
               Glossary:
                 summary: Using a Glossary
                 value:
@@ -931,13 +925,6 @@ paths:
                   $ref: '#/components/schemas/TranslationMemoryId'
                 translation_memory_threshold:
                   $ref: '#/components/schemas/TranslationMemoryThreshold'
-                enable_watermark:
-                  description: |-
-                    When `true`, adds a "Translated by DeepL" watermark to the translated document.
-
-                    Only supported for `docx` and `pdf` output. For all other output formats the parameter is ignored and the document is returned without a watermark.
-                  type: boolean
-                  default: false
                 enable_beta_languages:
                   description: |-
                     This parameter is maintained for backward compatibility and has no effect.

--- a/docs/resources/roadmap-and-release-notes.mdx
+++ b/docs/resources/roadmap-and-release-notes.mdx
@@ -10,11 +10,6 @@ rss: true
 </Update>
 
 <Update label="July 2026">
-## July 14 - Watermarking for Document Translation
-- [`POST /v2/document`](/api-reference/document/upload-and-translate-a-document) now accepts an `enable_watermark` parameter. When set to `true`, a "Translated by DeepL" watermark is applied to the translated document.
-- Supported for `docx` and `pdf` output only; the parameter is ignored for all other formats.
-- See the [document translation](/api-reference/document#request-body-descriptions) overview page for parameter details.
-
 ## July 2 - New Voice API Languages: Hindi, Malay, and Tamil
 - The Voice API now supports `hi` (Hindi), `ms` (Malay), and `ta` (Tamil) in beta. Translation is provided by DeepL; transcription and translated speech are provided by external service partners.
 - These languages are marked `"external": true` in the [`GET /v3/languages?resource=voice`](/docs/languages/using-the-languages-api) response. Because they are beta and external, call with `include=beta&include=external` to see them.


### PR DESCRIPTION
Reverts #399 to **unpublish** the `enable_watermark` documentation while an issue is investigated.

## What this removes

- `enable_watermark` parameter and the Watermark example on `POST /v2/document` (`openapi.yaml` + generated `openapi.json`).
- The **July 14 – Watermarking for Document Translation** changelog entry.

## Why

An issue was found with the watermarking feature/docs; unpublishing until it's resolved. The reference parameter and changelog entry can be re-introduced (via a new PR or by reverting this revert) once cleared.

Note: PR #400 (July 7 formats backfill) is unaffected.
