### PR TITLE
docs(document): restore enable_watermark for POST /v2/document

### DIFF
--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -1077,6 +1077,14 @@
                     "file": "@document.docx"
                   }
                 },
+                "Watermark": {
+                  "summary": "Adding a \"Translated by DeepL\" watermark (docx/pdf only)",
+                  "value": {
+                    "target_lang": "DE",
+                    "file": "@document.pdf",
+                    "enable_watermark": true
+                  }
+                },
                 "Glossary": {
                   "summary": "Using a Glossary",
                   "value": {
@@ -1168,6 +1176,11 @@
                   },
                   "translation_memory_threshold": {
                     "$ref": "#/components/schemas/TranslationMemoryThreshold"
+                  },
+                  "enable_watermark": {
+                    "description": "When `true`, adds a \"Translated by DeepL\" watermark to the translated document.\n\nOnly supported for `docx` and `pdf` output. For all other output formats the parameter is ignored and the document is returned without a watermark.",
+                    "type": "boolean",
+                    "default": false
                   },
                   "enable_beta_languages": {
                     "description": "This parameter is maintained for backward compatibility and has no effect.",

--- a/api-reference/openapi.yaml
+++ b/api-reference/openapi.yaml
@@ -827,6 +827,12 @@ paths:
                 value:
                   target_lang: DE
                   file: '@document.docx'
+              Watermark:
+                summary: Adding a "Translated by DeepL" watermark (docx/pdf only)
+                value:
+                  target_lang: DE
+                  file: '@document.pdf'
+                  enable_watermark: true
               Glossary:
                 summary: Using a Glossary
                 value:
@@ -925,6 +931,13 @@ paths:
                   $ref: '#/components/schemas/TranslationMemoryId'
                 translation_memory_threshold:
                   $ref: '#/components/schemas/TranslationMemoryThreshold'
+                enable_watermark:
+                  description: |-
+                    When `true`, adds a "Translated by DeepL" watermark to the translated document.
+
+                    Only supported for `docx` and `pdf` output. For all other output formats the parameter is ignored and the document is returned without a watermark.
+                  type: boolean
+                  default: false
                 enable_beta_languages:
                   description: |-
                     This parameter is maintained for backward compatibility and has no effect.

--- a/docs/resources/roadmap-and-release-notes.mdx
+++ b/docs/resources/roadmap-and-release-notes.mdx
@@ -13,6 +13,11 @@ rss: true
 ## July 16 - Combined Status Page
 - DeepL now publishes a single [status page](https://www.deeplstatus.com) covering all services, with a dedicated [API view](https://www.deeplstatus.com/?tab=api) for real-time API status and incidents.
 
+## July 14 - Watermarking for Document Translation
+- [`POST /v2/document`](/api-reference/document/upload-and-translate-a-document) now accepts an `enable_watermark` parameter. When set to `true`, a "Translated by DeepL" watermark is applied to the translated document.
+- Supported for `docx` and `pdf` output only; the parameter is ignored for all other formats.
+- See the [document translation](/api-reference/document#request-body-descriptions) overview page for parameter details.
+
 ## July 7 - New Document Formats and Higher File Size Limits
 - [`POST /v2/document`](/api-reference/document/upload-and-translate-a-document) now supports five additional file formats: `idml` (Adobe InDesign), `xml`, `json`, `dita` (DITA topics), and `mif` (Adobe FrameMaker).
 - XLIFF support has been expanded to versions 1.2, 2.0, and 2.1 (previously 2.1 only).


### PR DESCRIPTION
Re-publishes the `enable_watermark` documentation that was rolled back in #401.

The API-side issue that prompted the rollback is resolved, so document watermarking is documented again.

## Restores

- `enable_watermark` parameter + Watermark (pdf) example on `POST /v2/document` (`openapi.yaml`; `openapi.json` regenerated by CI).
- **July 14 – Watermarking for Document Translation** changelog entry (slotted back into chronological order, between July 16 and July 7).

Effectively a revert of #401 (revert-of-revert of #399), re-resolved against current `main`.
