### PR TITLE
Move German (Swiss) and French (Canadian) out of beta

### DIFF
--- a/docs/getting-started/supported-languages.mdx
+++ b/docs/getting-started/supported-languages.mdx
@@ -14,9 +14,11 @@ import { LanguageTable } from "/snippets/language-table.jsx"
 
 <LanguageTable />
 
+{/* Re-enable when the languages table includes beta languages again:
 <Info>
   Currently, characters translated into beta languages are not billed. See [Alpha and beta features](/docs/resources/alpha-and-beta-features) for more information.
 </Info>
+*/}
 
 <Info>
   Style rules are supported for the following target languages: `de`, `en`, `es`, `fr`, `it`, `ja`, `ko`, and `zh`. For more details, see the [Style Rules API documentation](/docs/customize/using-style-rules). Writing style and tone availability for `/write/rephrase` can also be retrieved via [`GET /v3/languages?resource=write`](/docs/languages/using-the-languages-api).

--- a/docs/resources/roadmap-and-release-notes.mdx
+++ b/docs/resources/roadmap-and-release-notes.mdx
@@ -10,6 +10,11 @@ rss: true
 </Update>
 
 <Update label="July 2026">
+## July 17 - German (Swiss) and French (Canadian) Generally Available
+- `de-CH` (German, Swiss) and `fr-CA` (French, Canadian) target language variants have moved out of beta and are now generally available for text and document translation.
+- Characters translated into these languages are now billed and count against your character threshold, like other supported languages. During the beta phase, they were not billed.
+- See the [supported languages table](/docs/getting-started/supported-languages) for the full list of variants and their supported features.
+
 ## July 16 - Combined Status Page
 - DeepL now publishes a single [status page](https://www.deeplstatus.com) covering all services, with a dedicated [API view](https://www.deeplstatus.com/?tab=api) for real-time API status and incidents.
 

--- a/snippets/language-table.jsx
+++ b/snippets/language-table.jsx
@@ -46,10 +46,10 @@ export const LanguageTable = () => {
         { code: 'ZH', name: 'Chinese (unspecified variant)', translation: true, isVariant: false, glossaries: true, tagHandling: true, textImprovement: false, translationMemory: true, styleRules: true },
 
         // Target-only language variants (cannot be used as source)
-        { code: 'DE-CH', name: 'German (Swiss)', translation: true, isVariant: true, isBeta: true, glossaries: true, tagHandling: false, textImprovement: false, translationMemory: false, styleRules: true },
+        { code: 'DE-CH', name: 'German (Swiss)', translation: true, isVariant: true, glossaries: true, tagHandling: false, textImprovement: false, translationMemory: false, styleRules: true },
         { code: 'EN-GB', name: 'English (British)', translation: true, isVariant: true, glossaries: true, tagHandling: true, textImprovement: true, translationMemory: true, styleRules: false },
         { code: 'EN-US', name: 'English (American)', translation: true, isVariant: true, glossaries: true, tagHandling: true, textImprovement: true, translationMemory: true, styleRules: false },
-        { code: 'FR-CA', name: 'French (Canadian)', translation: true, isVariant: true, isBeta: true, glossaries: true, tagHandling: false, textImprovement: false, translationMemory: false, styleRules: true },
+        { code: 'FR-CA', name: 'French (Canadian)', translation: true, isVariant: true, glossaries: true, tagHandling: false, textImprovement: false, translationMemory: false, styleRules: true },
         { code: 'PT-BR', name: 'Portuguese (Brazilian)', translation: true, isVariant: true, glossaries: true, tagHandling: true, textImprovement: true, translationMemory: false, styleRules: false },
         { code: 'PT-PT', name: 'Portuguese (European)', translation: true, isVariant: true, glossaries: true, tagHandling: true, textImprovement: false, translationMemory: false, styleRules: false },
         { code: 'ZH-HANS', name: 'Chinese (simplified)', translation: true, isVariant: true, glossaries: true, tagHandling: true, textImprovement: true, translationMemory: true, styleRules: false },


### PR DESCRIPTION
## Summary
Moves the `de-CH` (German, Swiss) and `fr-CA` (French, Canadian) target language variants out of beta and into general availability.

## Changes
- **`snippets/language-table.jsx`** — Remove the `isBeta` flag from `DE-CH` and `FR-CA`, dropping the "Beta" tag and its "not billed" tooltip from those rows.
- **`docs/resources/roadmap-and-release-notes.mdx`** — Add a July 17, 2026 changelog entry noting GA status and that billing now resumes.
- **`docs/getting-started/supported-languages.mdx`** — Comment out (rather than delete) the "beta languages are not billed" `<Info>` box, since these were the only beta entries in the table. Kept in place for reuse if a beta language returns.

## Notes
- Historical April 17 / April 30 changelog entries are left untouched as a record of what happened.
- The OpenAPI spec doesn't reference these codes, so no spec changes were needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)