### PR TITLE
docs: Admin API now available to all API Pro subscribers

### DIFF
--- a/docs/admin/managing-api-keys.mdx
+++ b/docs/admin/managing-api-keys.mdx
@@ -108,7 +108,7 @@ The "Permissions" column in the key table shows each key's status as a badge. Ho
 
 ## Manage admin API keys
 
-If your account has [Admin API access](/docs/admin/overview#the-admin-api), you manage admin keys separately in the ["Admin Keys" tab](https://www.deepl.com/your-account/admin).
+On the API Pro, API Growth, and API Enterprise plans, you manage [admin keys](/docs/admin/overview#the-admin-api) separately in the ["Admin Keys" tab](https://www.deepl.com/your-account/admin).
 
 <Frame caption="The Admin Keys tab">
 ![](/_assets/images/admin-api-tab.png)
@@ -118,5 +118,5 @@ Admin keys support the same actions as developer keys: create, copy, rename, and
 
 - Admin keys always end with an `:adm` suffix, which distinguishes them from developer keys
 - Unnamed admin keys are called "DeepL Admin Key" by default
-- You can create up to 25 simultaneously active admin keys on any plan with Admin API access
+- You can create up to 25 simultaneously active admin keys
 - Usage limits and permissions don't apply to admin keys

--- a/docs/admin/overview.mdx
+++ b/docs/admin/overview.mdx
@@ -12,7 +12,7 @@ You can administer your DeepL API subscription in two ways:
 
 ## The Admin API
 
-The Admin API is available to all API Growth and API Enterprise subscribers, and to a limited set of Pro API subscribers. To enable access, contact your DeepL customer success manager or DeepL support.
+The Admin API is available to all API Pro, API Growth, and API Enterprise subscribers.
 
 The Admin API uses its own key type: admin keys, which always carry an `:adm` suffix to distinguish them from developer keys. You create admin keys in the ["Admin Keys" tab](https://www.deepl.com/your-account/admin) of your account (see [Managing API Keys in the Account UI](/docs/admin/managing-api-keys#manage-admin-api-keys)) and pass them in the `Authorization` header of each request, just like developer keys:
 

--- a/docs/admin/quickstart.mdx
+++ b/docs/admin/quickstart.mdx
@@ -16,7 +16,7 @@ In this tutorial, we'll use the Admin API to provision a new developer API key f
 
 ## Prerequisites
 
-- An API Growth or API Enterprise subscription, or a Pro API subscription with [Admin API access](/docs/admin/overview#the-admin-api)
+- An API Pro, API Growth, or API Enterprise subscription (see [The Admin API](/docs/admin/overview#the-admin-api))
 - An [**admin API key**](/docs/admin/managing-api-keys#manage-admin-api-keys) for your DeepL organization. Regular developer keys cannot access Admin API endpoints.
 - `curl` installed on your machine
 

--- a/docs/admin/retrieving-usage-data.mdx
+++ b/docs/admin/retrieving-usage-data.mdx
@@ -67,7 +67,7 @@ The [`/usage` endpoint](/api-reference/usage-and-quota/check-usage-and-limits) r
 
 ## Admin API analytics
 
-The Admin API provides programmatic access to usage data over a custom date range, with optional grouping by day. It requires [Admin API access](/docs/admin/overview#the-admin-api) and an [admin key](/docs/admin/managing-api-keys#manage-admin-api-keys) for authentication. Two endpoints are available:
+The [Admin API](/docs/admin/overview#the-admin-api) provides programmatic access to usage data over a custom date range, with optional grouping by day. It requires an [admin key](/docs/admin/managing-api-keys#manage-admin-api-keys) for authentication. Two endpoints are available:
 
 - [Get usage analytics](/api-reference/admin-api/get-usage-analytics) returns usage statistics across all services (text translation, document translation, text improvement, and speech-to-text), in total or grouped by API key
 - [Get custom tag usage analytics](/api-reference/admin-api/get-custom-tag-usage-analytics) returns usage broken down by custom tag

--- a/docs/resources/roadmap-and-release-notes.mdx
+++ b/docs/resources/roadmap-and-release-notes.mdx
@@ -10,6 +10,11 @@ rss: true
 </Update>
 
 <Update label="July 2026">
+## July 22 - Admin API Available to All API Pro Subscribers
+- The [Admin API](/docs/admin/overview#the-admin-api), which lets admins [manage developer keys](/api-reference/admin-api/managing-developer-keys/create-key) programmatically and retrieve [usage analytics](/docs/admin/retrieving-usage-data#admin-api-analytics) grouped by API key or custom tag, is now available to all API Pro subscribers, in addition to API Growth and API Enterprise subscribers.
+- Previously, API Pro subscribers had to request access through their customer success manager or DeepL support. No action is required to enable access.
+- Create an admin key in the ["Admin Keys" tab](https://www.deepl.com/your-account/admin) of your account to get started. See [Managing API Keys in the Account UI](/docs/admin/managing-api-keys#manage-admin-api-keys) for instructions, or jump into the [Admin API Quickstart](/docs/admin/quickstart).
+
 ## July 17 - German (Swiss) and French (Canadian) Generally Available
 - `de-CH` (German, Swiss) and `fr-CA` (French, Canadian) target language variants have moved out of beta and are now generally available for text and document translation.
 - Characters translated into these languages are now billed and count against your character threshold, like other supported languages. During the beta phase, they were not billed.


### PR DESCRIPTION
Remove request-access gating language now that the Admin API is enabled for all API Pro subscriptions, and add a changelog entry. API Growth and API Enterprise availability is unchanged.