### PR TITLE
spec: add speech-to-speech to the admin API

### DIFF
--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -8,7 +8,7 @@
       "name": "DeepL - Contact us",
       "url": "https://www.deepl.com/contact-us"
     },
-    "version": "3.12.0"
+    "version": "3.13.0"
   },
   "externalDocs": {
     "description": "DeepL Pro - Plans and pricing",
@@ -150,7 +150,8 @@
                           "text_translation_characters": 4892,
                           "document_translation_characters": 0,
                           "text_improvement_characters": 4727,
-                          "speech_to_text_minutes": 107.46
+                          "speech_to_text_minutes": 107.46,
+                          "speech_to_speech_minutes": 42.11
                         },
                         "group_by": "key_and_day",
                         "start_date": "2025-09-29T00:00:00",
@@ -165,7 +166,8 @@
                               "text_translation_characters": 159,
                               "document_translation_characters": 0,
                               "text_improvement_characters": 156,
-                              "speech_to_text_minutes": 11.94
+                              "speech_to_text_minutes": 11.94,
+                              "speech_to_speech_minutes": 3.72
                             }
                           }
                         ]
@@ -181,7 +183,8 @@
                           "text_translation_characters": 4892,
                           "document_translation_characters": 0,
                           "text_improvement_characters": 4727,
-                          "speech_to_text_minutes": 107.46
+                          "speech_to_text_minutes": 107.46,
+                          "speech_to_speech_minutes": 42.11
                         },
                         "start_date": "2025-09-29T00:00:00",
                         "end_date": "2025-10-01T00:00:00"
@@ -668,6 +671,7 @@
         ],
         "summary": "Set developer key usage limits as an admin",
         "operationId": "adminSetDeveloperKeyUsageLimits",
+        "description": "Sets the usage limits for a developer key. This replaces all limits for the key: any\nlimit omitted from the request is reset to `null` (disabled). To change one limit while\nkeeping the others, include their current values in the request.\n",
         "requestBody": {
           "required": true,
           "content": {
@@ -686,6 +690,9 @@
                   },
                   "speech_to_text_milliseconds": {
                     "$ref": "#/components/schemas/ApiKeyUsageSpeechToTextMilliseconds"
+                  },
+                  "speech_to_speech_milliseconds": {
+                    "$ref": "#/components/schemas/ApiKeyUsageSpeechToSpeechMilliseconds"
                   }
                 }
               }
@@ -6261,6 +6268,11 @@
         "type": "number",
         "example": 3600000
       },
+      "ApiKeyUsageSpeechToSpeechMilliseconds": {
+        "description": "Restricts the number of milliseconds of speech-to-speech that can be consumed by an API key in a one-month usage period.\nSetting the limit to `0` means the API key will not be able to consume speech-to-speech milliseconds.\nSetting the limit to `null` disables the limit, effectively allowing unlimited usage.\n",
+        "type": "number",
+        "example": 3600000
+      },
       "ApiKey": {
         "description": "The API key.",
         "type": "object",
@@ -6295,6 +6307,9 @@
               },
               "speech_to_text_milliseconds": {
                 "$ref": "#/components/schemas/ApiKeyUsageSpeechToTextMilliseconds"
+              },
+              "speech_to_speech_milliseconds": {
+                "$ref": "#/components/schemas/ApiKeyUsageSpeechToSpeechMilliseconds"
               }
             }
           }
@@ -9220,6 +9235,11 @@
             "type": "number",
             "description": "Duration of speech-to-text usage in minutes.",
             "example": 107.46
+          },
+          "speech_to_speech_minutes": {
+            "type": "number",
+            "description": "Duration of speech-to-speech usage in minutes.",
+            "example": 42.11
           }
         }
       },

--- a/api-reference/openapi.yaml
+++ b/api-reference/openapi.yaml
@@ -9,7 +9,7 @@ info:
   contact:
     name: DeepL - Contact us
     url: https://www.deepl.com/contact-us
-  version: 3.12.0
+  version: 3.13.0
 externalDocs:
   description: DeepL Pro - Plans and pricing
   url: https://www.deepl.com/pro#developer
@@ -164,6 +164,7 @@ paths:
                         document_translation_characters: 0
                         text_improvement_characters: 4727
                         speech_to_text_minutes: 107.46
+                        speech_to_speech_minutes: 42.11
                       group_by: "key_and_day"
                       start_date: "2025-09-29T00:00:00"
                       end_date: "2025-10-01T00:00:00"
@@ -177,6 +178,7 @@ paths:
                           document_translation_characters: 0
                           text_improvement_characters: 156
                           speech_to_text_minutes: 11.94
+                          speech_to_speech_minutes: 3.72
                 withoutGrouping:
                   summary: Usage report without grouping
                   value:
@@ -187,6 +189,7 @@ paths:
                         document_translation_characters: 0
                         text_improvement_characters: 4727
                         speech_to_text_minutes: 107.46
+                        speech_to_speech_minutes: 42.11
                       start_date: "2025-09-29T00:00:00"
                       end_date: "2025-10-01T00:00:00"
         400:
@@ -6830,6 +6833,10 @@ components:
           type: number
           description: Duration of speech-to-text usage in minutes.
           example: 107.46
+        speech_to_speech_minutes:
+          type: number
+          description: Duration of speech-to-speech usage in minutes.
+          example: 42.11
     KeyAndDayUsageItem:
       type: object
       description: Usage statistics for a specific API key and optionally a specific date.

--- a/api-reference/openapi.yaml
+++ b/api-reference/openapi.yaml
@@ -498,6 +498,10 @@ paths:
         - AdminApi
       summary: Set developer key usage limits as an admin
       operationId: adminSetDeveloperKeyUsageLimits
+      description: |
+        Sets the usage limits for a developer key. This replaces all limits for the key: any
+        limit omitted from the request is reset to `null` (disabled). To change one limit while
+        keeping the others, include their current values in the request.
       requestBody:
         required: true
         content:
@@ -513,6 +517,8 @@ paths:
                   $ref: '#/components/schemas/ApiKeyUsageCharacters'
                 speech_to_text_milliseconds:
                   $ref: '#/components/schemas/ApiKeyUsageSpeechToTextMilliseconds'
+                speech_to_speech_milliseconds:
+                  $ref: '#/components/schemas/ApiKeyUsageSpeechToSpeechMilliseconds'
       responses:
         200:
           description: The set usage limits function returns a JSON representation of the modified API key.
@@ -4274,6 +4280,13 @@ components:
         Setting the limit to `null` disables the limit, effectively allowing unlimited usage.
       type: number
       example: 3600000
+    ApiKeyUsageSpeechToSpeechMilliseconds:
+      description: |
+        Restricts the number of milliseconds of speech-to-speech that can be consumed by an API key in a one-month usage period.
+        Setting the limit to `0` means the API key will not be able to consume speech-to-speech milliseconds.
+        Setting the limit to `null` disables the limit, effectively allowing unlimited usage.
+      type: number
+      example: 3600000
     ApiKey:
       description: The API key.
       type: object
@@ -4302,6 +4315,8 @@ components:
               $ref: '#/components/schemas/ApiKeyUsageCharacters'
             speech_to_text_milliseconds:
               $ref: '#/components/schemas/ApiKeyUsageSpeechToTextMilliseconds'
+            speech_to_speech_milliseconds:
+              $ref: '#/components/schemas/ApiKeyUsageSpeechToSpeechMilliseconds'
     ConfiguredRules:
       description: The enabled rules for the style rule list including what option
         was selected for each rule. This schema combines rules from all supported


### PR DESCRIPTION
Documents the speech-to-speech fields on the Admin API, completing the STS rollout in the spec (usage fields on `GET /v2/usage` landed in #383).

- `speech_to_speech_milliseconds` in the developer-key usage-limits request and in `usage_limits` on the key representation (mirrors the STT limit; already live in the API)
- `speech_to_speech_minutes` in the `UsageBreakdown` used by `GET /v2/admin/analytics` (total, per-key, and per-key-and-day), plus examples
- a description for `adminSetDeveloperKeyUsageLimits` clarifying the replace-all semantics of the endpoint
- version bump 3.12.0 -> 3.13.0

Draft until the analytics field is live in prod; the limits fields are live already.