### PR TITLE
Move feature comparison table to the customize overview

### DIFF
--- a/docs/customize/overview.mdx
+++ b/docs/customize/overview.mdx
@@ -25,7 +25,7 @@ Glossaries and style rules are unique to each of DeepL's global data centers and
 
 ## Choosing the right feature
 
-Use this table to decide which feature fits your use case. It also covers the [`context` parameter](/docs/learning-how-tos/examples-and-guides/how-to-use-context-parameter), which isn't a customization feature but is often the right tool for ambiguous or short text.
+Here's when to use each customization feature for the best results. The [`context` parameter](/docs/learning-how-tos/examples-and-guides/how-to-use-context-parameter) can also be used to improve translations of ambiguous or short text.
 
 | Use case | Glossaries | Style rules | Custom instructions | Translation memories | Context parameter |
 | :---- | :----: | :----: | :----: | :----: | :----: |

--- a/docs/customize/overview.mdx
+++ b/docs/customize/overview.mdx
@@ -23,6 +23,20 @@ Glossaries, style rules, custom instructions, and translation memories work with
 Glossaries and style rules are unique to each of DeepL's global data centers and are not shared between them. Clients using [regional endpoints](/docs/getting-started/regional-endpoints) can't access glossaries or style rules created in the UI at this time.
 </Warning>
 
+## Choosing the right feature
+
+Each feature solves a different problem, and the [`context` parameter](/docs/learning-how-tos/examples-and-guides/how-to-use-context-parameter) overlaps with them: it isn't a stored customization, but it's often the right tool for ambiguous or short text. Use this table to decide which feature fits your use case.
+
+| Use case | Context parameter | Glossaries | Style rules | Custom instructions | Translation memories |
+| :---- | :----: | :----: | :----: | :----: | :----: |
+| **Ambiguous words or short snippets** | ✅ | ❌ | ❌ | ❌ | ❌ |
+| **Consistent gender or name spelling** | ✅ | ❌ | ❌ | ❌ | ❌ |
+| **Consistent domain-specific terminology** | ❌ | ✅ | ❌ | ❌ | ❌ |
+| **Brand and product names** | ❌ | ✅ | ❌ | ❌ | ❌ |
+| **Formatting conventions (dates, numbers, punctuation)** | ❌ | ❌ | ✅ | ❌ | ❌ |
+| **Tone and phrasing** | ❌ | ❌ | ❌ | ✅ | ❌ |
+| **Reusing previously approved translations** | ❌ | ❌ | ❌ | ❌ | ✅ |
+
 ## Feature guides
 
 <CardGroup cols={2}>

--- a/docs/customize/overview.mdx
+++ b/docs/customize/overview.mdx
@@ -25,17 +25,17 @@ Glossaries and style rules are unique to each of DeepL's global data centers and
 
 ## Choosing the right feature
 
-Each feature solves a different problem, and the [`context` parameter](/docs/learning-how-tos/examples-and-guides/how-to-use-context-parameter) overlaps with them: it isn't a stored customization, but it's often the right tool for ambiguous or short text. Use this table to decide which feature fits your use case.
+Use this table to decide which feature fits your use case. It also covers the [`context` parameter](/docs/learning-how-tos/examples-and-guides/how-to-use-context-parameter), which isn't a customization feature but is often the right tool for ambiguous or short text.
 
-| Use case | Context parameter | Glossaries | Style rules | Custom instructions | Translation memories |
+| Use case | Glossaries | Style rules | Custom instructions | Translation memories | Context parameter |
 | :---- | :----: | :----: | :----: | :----: | :----: |
-| **Ambiguous words or short snippets** | ✅ | ❌ | ❌ | ❌ | ❌ |
-| **Consistent gender or name spelling** | ✅ | ❌ | ❌ | ❌ | ❌ |
-| **Consistent domain-specific terminology** | ❌ | ✅ | ❌ | ❌ | ❌ |
-| **Brand and product names** | ❌ | ✅ | ❌ | ❌ | ❌ |
-| **Formatting conventions (dates, numbers, punctuation)** | ❌ | ❌ | ✅ | ❌ | ❌ |
-| **Tone and phrasing** | ❌ | ❌ | ❌ | ✅ | ❌ |
-| **Reusing previously approved translations** | ❌ | ❌ | ❌ | ❌ | ✅ |
+| **Consistent domain-specific terminology** | ✅ | ❌ | ❌ | ❌ | ❌ |
+| **Brand and product names** | ✅ | ❌ | ❌ | ❌ | ❌ |
+| **Formatting conventions (dates, numbers, punctuation)** | ❌ | ✅ | ❌ | ❌ | ❌ |
+| **Tone and phrasing** | ❌ | ❌ | ✅ | ❌ | ❌ |
+| **Reusing previously approved translations** | ❌ | ❌ | ❌ | ✅ | ❌ |
+| **Ambiguous words or short snippets** | ❌ | ❌ | ❌ | ❌ | ✅ |
+| **Consistent gender or name spelling** | ❌ | ❌ | ❌ | ❌ | ✅ |
 
 ## Feature guides
 

--- a/docs/learning-how-tos/examples-and-guides/how-to-use-context-parameter.mdx
+++ b/docs/learning-how-tos/examples-and-guides/how-to-use-context-parameter.mdx
@@ -227,7 +227,7 @@ curl -X POST 'https://api.deepl.com/v2/translate' \
 
 ## Choosing the right feature
 
-The `context` parameter is one of several ways to influence translation output. For a comparison of `context` with glossaries, style rules, custom instructions, and translation memories, see [Choosing the right feature](/docs/customize/overview#choosing-the-right-feature) on the Customize overview.
+The `context` parameter is one of several ways to influence translation output. For a comparison of `context` with glossaries, style rules, custom instructions, and translation memories, see [Choosing the right feature](/docs/customize/overview#choosing-the-right-feature).
 
 ---
 

--- a/docs/learning-how-tos/examples-and-guides/how-to-use-context-parameter.mdx
+++ b/docs/learning-how-tos/examples-and-guides/how-to-use-context-parameter.mdx
@@ -7,7 +7,7 @@ public: true
 **This guide shows you:**
 - When to use `context` (and when not to)
 - How to use `context` to resolve ambiguous words, genders, or transliterations
-- How to choose between `context`, Glossaries, and Style Rules
+- Where to find a comparison of `context` with DeepL's customization features
 
 ---
 
@@ -225,19 +225,9 @@ curl -X POST 'https://api.deepl.com/v2/translate' \
 
 ---
 
-## Choosing the right feature for your needs
+## Choosing the right feature
 
-Different DeepL features solve different problems. Use this table to decide which best suits your use case.
-
-| Use Case | Context Parameter | Glossaries | Style Rules |
-|----------|:----------------:|:----------:|:-----------:|
-| **Ambiguous words** | ✅ | ❌ | ❌ |
-| **Consistent gender or spelling** | ✅ | ❌ | ❌ |
-| **Consistent domain-specific terminology** | ❌ | ✅ | ❌ |
-| **Brand names** | ❌ | ✅ | ❌ |
-| **Tone and style** | ❌ | ❌ | ✅ |
-| **Formatting rules** | ❌ | ❌ | ✅ |
-| **Translation instructions** | ❌ | ❌ | ✅ |
+The `context` parameter is one of several ways to influence translation output. For a comparison of `context` with glossaries, style rules, custom instructions, and translation memories, see [Choosing the right feature](/docs/customize/overview#choosing-the-right-feature) on the Customize overview.
 
 ---
 


### PR DESCRIPTION
Stacked on #413.

## Summary

- Moves the "Choosing the right feature" use-case table off the context parameter guide and onto the Customize overview, where the feature docs live
- Expands the table: custom instructions get their own column (the overview treats them as a distinct feature) and translation memories are added with a "Reusing previously approved translations" row
- The context parameter guide now links to the table; its intro notes that `context` isn't a stored customization but overlaps with those features

## Test plan

- `mint broken-links --check-anchors` passes for both edited pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)